### PR TITLE
Bug fix and unit test for Block Comment Evaluator

### DIFF
--- a/backend_plugin/META-INF/MANIFEST.MF
+++ b/backend_plugin/META-INF/MANIFEST.MF
@@ -10,7 +10,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench.texteditor,
  org.eclipse.jface.text;bundle-version="3.15.0",
  org.eclipse.ui.ide;bundle-version="3.14.200",
- org.eclipse.jdt.core;bundle-version="3.16.0"
+ org.eclipse.jdt.core;bundle-version="3.16.0",
+ org.junit
 Bundle-RequiredExecutionEnvironment: JavaSE-9
 Automatic-Module-Name: Plugin_test
 Import-Package: org.eclipse.jface.text

--- a/backend_plugin/src/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/evaluators/BlockCommentEvaluator.java
@@ -60,7 +60,7 @@ public class BlockCommentEvaluator {
 						
 						// Check if consecutive lines
 						int prevToCurrentDif = currentRegion.getOffset() - (prevRegion.getOffset() + prevRegion.getLength());
-						int currentToPrevDif = currentRegion.getOffset() + currentRegion.getLength() - prevRegion.getOffset();
+						int currentToPrevDif = prevRegion.getOffset() - (currentRegion.getOffset() + currentRegion.getLength());
 						
 						// Uses a buffer of 2 characters because sometimes IRegion doesn't count the newly inserted "//"
 						if ((prevToCurrentDif >= 0 && prevToCurrentDif <= 2) || 

--- a/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
@@ -82,7 +82,6 @@ public class BlockCommentEvaluatorTest {
 		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
 		length = 1;
 		textAdded = "/";
-		System.out.println("Starting test 2");
 		// Create mock document event changes
 		try {
 			// Mock a document event with a single backslash placed at the beginning of the third line

--- a/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
@@ -1,0 +1,114 @@
+package tests;
+
+import static org.junit.Assert.*;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+import org.junit.Test;
+
+import evaluators.BlockCommentEvaluator;
+
+/**
+ * Unit test for BlockCommentEvaluator
+ */
+public class BlockCommentEvaluatorTest {
+	
+	private static String content = "Line1\n Line2\n Line3\n";
+
+	/**
+	 * Tests the block comment evaluation function returns true when line 0 then line 1 of a document are commented out
+	 */
+	@Test
+	public void consecutiveLinesDownCommentedOut() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+		
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+		
+		// Send mock data
+		// Mock a document event with a single backslash placed at the beginning of the first line
+		offset = 0;
+		length = 1;
+		textAdded = "/";
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+		// Place a second backslash after the first
+		offset++;
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+		
+		// Pull the offset for the start of the second line so we aren't guessing
+		try {
+			// Place a single backslash at the start of the second line
+			offset = doc.getLineOffset(1);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+			
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			fail("BadLocationException thrown in consecutiveLinesDownCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+	
+
+	/**
+	 * Tests the block comment evaluation function returns true when line 2 then line 1 of a document are commented out
+	 */
+	@Test
+	public void consecutiveLinesUpCommentedOut() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+		
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+		length = 1;
+		textAdded = "/";
+		System.out.println("Starting test 2");
+		// Create mock document event changes
+		try {
+			// Mock a document event with a single backslash placed at the beginning of the third line
+			offset = doc.getLineOffset(2);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+		
+			// Place a second backslash after the first
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+		
+			// Mock a document event with a single backslash placed at the beginning of the second line
+			offset = doc.getLineOffset(1);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+			
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			fail("BadLocationException thrown in consecutiveLinesUpCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/tests/BlockCommentEvaluatorTest.java
@@ -15,7 +15,7 @@ import evaluators.BlockCommentEvaluator;
  */
 public class BlockCommentEvaluatorTest {
 	
-	private static String content = "Line1\n Line2\n Line3\n";
+	private static final String content = "Line1\n Line2\n Line3\n";
 
 	/**
 	 * Tests the block comment evaluation function returns true when line 0 then line 1 of a document are commented out
@@ -58,12 +58,12 @@ public class BlockCommentEvaluatorTest {
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluate(event));
 		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
 			fail("BadLocationException thrown in consecutiveLinesDownCommentedOut Test");
 			e.printStackTrace();
 		}
 	}
-
-	
 
 	/**
 	 * Tests the block comment evaluation function returns true when line 2 then line 1 of a document are commented out
@@ -105,9 +105,10 @@ public class BlockCommentEvaluatorTest {
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluate(event));
 		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
 			fail("BadLocationException thrown in consecutiveLinesUpCommentedOut Test");
 			e.printStackTrace();
 		}
 	}
-
 }


### PR DESCRIPTION
Created a preliminary unit test for BlockCommentEvaluator.

More work needs to be done on this, but this shows that we can mock document change events reliably. 

Creating these tests already found one bug in how the BC Evaluator was calculating consecutive lines. That was also fixed in this PR.