### PR TITLE
Block comment evaluator checks for white space before "//"

### DIFF
--- a/backend_plugin/src/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/evaluators/BlockCommentEvaluator.java
@@ -2,6 +2,7 @@ package evaluators;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 
 /**
@@ -9,15 +10,7 @@ import org.eclipse.jface.text.IRegion;
  * then the user should be notified of the block comment feature in Eclipse.
  */
 public class BlockCommentEvaluator {
-	
-	// Dev notes:
-	// Currently working for consecutive lines (going up or down consecutively)
-	// However, provides false positive if you comment mid line
-	
-	// TODO:
-	// Determine when double slash is put at beginning of line and only track that
-	// Determine if double slash is put on multiple lines with a blank line between
-	
+		
 	private boolean firstBackSlashDetected;
 	private IRegion prevRegion;
 	private int prevOffset;
@@ -28,7 +21,6 @@ public class BlockCommentEvaluator {
 	 */
 	public BlockCommentEvaluator() {
 		firstBackSlashDetected = false;
-		this.prevInsert = "";
 	}
 	
 	/**
@@ -37,55 +29,72 @@ public class BlockCommentEvaluator {
 	 * @return true if the user comments two sequential lines of code, false otherwise
 	 */
 	public boolean evaluate(DocumentEvent event) {
-		
+
 		// Took logic Eric created to check for a double back slash
 		// May be a way to optimize this, but it works
 		int currentOffset = event.getOffset();
-		java.lang.String currentInsert = event.getText();
+		String currentInsert = event.getText();
 		if (prevOffset == currentOffset - 1) {
 			if (currentInsert != null && this.prevInsert != null &&
-				this.prevInsert.equals("/") && currentInsert.equals("/")) {
+					this.prevInsert.equals("/") && currentInsert.equals("/")) {
+
+				// DEBUG
 				System.out.println("Placed two slashes");
-				
-				// If we have two back slashes, then check if we've found two previously
-				if (firstBackSlashDetected) {
-					try {
-						IRegion currentRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
-						
+
+				// Verify that the double backslash is at the start of the line
+				IDocument doc = event.getDocument();
+				try {
+					int lineOffset = doc.getLineInformationOfOffset(currentOffset).getOffset();
+					String textBeforeSlashes = doc.get(lineOffset, prevOffset-lineOffset);
+
+					// DEBUG
+					//					System.out.println("line offset: " + lineOffset);
+					//					System.out.println("Prev offset: " + prevOffset);
+					//					System.out.println("Text before slashes: " + textBeforeSlashes);
+
+					textBeforeSlashes = textBeforeSlashes.trim();
+					if (textBeforeSlashes.isEmpty()) {
+
 						// DEBUG
-//						System.out.println("Current Region pos: " + currentRegion.getOffset());
-//						System.out.println("Current REgion length: " + currentRegion.getLength());
-//						System.out.println("Prev Region pos: " + prevRegion.getOffset());
-//						System.out.println("Prev Region length: " + prevRegion.getLength());
-						
-						// Check if consecutive lines
-						int prevToCurrentDif = currentRegion.getOffset() - (prevRegion.getOffset() + prevRegion.getLength());
-						int currentToPrevDif = prevRegion.getOffset() - (currentRegion.getOffset() + currentRegion.getLength());
-						
-						// Uses a buffer of 2 characters because sometimes IRegion doesn't count the newly inserted "//"
-						if ((prevToCurrentDif >= 0 && prevToCurrentDif <= 2) || 
-								(currentToPrevDif >= 0 && currentToPrevDif <= 2)) { 
-							firstBackSlashDetected = false;
-							return true;
+//						System.out.println("Start of line!");
+
+						// If we have two back slashes, then check if we've found two previously
+						if (firstBackSlashDetected) {
+							IRegion currentRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
+
+							// DEBUG
+							// System.out.println("Current Region pos: " + currentRegion.getOffset());
+							// System.out.println("Current REgion length: " + currentRegion.getLength());
+							// System.out.println("Prev Region pos: " + prevRegion.getOffset());
+							// System.out.println("Prev Region length: " + prevRegion.getLength());
+
+							// Check if consecutive lines
+							int prevToCurrentDif = currentRegion.getOffset() - (prevRegion.getOffset() + prevRegion.getLength());
+							int currentToPrevDif = prevRegion.getOffset() - (currentRegion.getOffset() + currentRegion.getLength());
+
+							// Uses a buffer of 2 characters because sometimes IRegion doesn't count the newly inserted "//"
+							if ((prevToCurrentDif >= 0 && prevToCurrentDif <= 2) ||
+									(currentToPrevDif >= 0 && currentToPrevDif <= 2)) {
+								firstBackSlashDetected = false;
+								return true;
+							}
+
+							// If not consecutive, then update prevRegion
+							prevRegion = currentRegion;
+
+							// If we haven't seen a double back slash yet
+						} else {
+							firstBackSlashDetected = true;
+							prevRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
 						}
-						
-						// If not consecutive, then update prevRegion
-						prevRegion = currentRegion;
-						
-					} catch (BadLocationException e) {
-						System.out.println("Bad offset location"); // shouldn't be able to get here
-						firstBackSlashDetected = false;
 					}
-				// If we haven't seen a double back slash yet
-				} else {
-					firstBackSlashDetected = true;
-					try {
-						prevRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
-					} catch (BadLocationException e) {
-						System.out.println("Bad offset location"); // shouldn't be able to get here
-						firstBackSlashDetected = false;
-					}
-				}	
+				// Try Catch needed in case offset passed in doc.get methods doesn't actually exist
+				// We shouldn't actually get here, but since it's all asynchronous, something weird may happen
+				} catch (BadLocationException e) {
+					// DEBUG
+					System.out.println("Bad offset location in BlockCommentEvaluator"); // shouldn't be able to get here
+					firstBackSlashDetected = false;
+				}
 			}
 		}
 		// Update the previous event offset and character
@@ -94,5 +103,4 @@ public class BlockCommentEvaluator {
 
 		return false;
 	}
-
 }


### PR DESCRIPTION
Refined block comment evaluation function.

Now checks that there is only white space between the "//" and the start of the line where the "//" resides in the document.

I left all the debug println statements in, but I'm open to removing them at this juncture. 

Also cleaned up a couple spacing and formatting issues.