### PR TITLE
Removed toolbar button and menu for plugin

### DIFF
--- a/backend_plugin/plugin.xml
+++ b/backend_plugin/plugin.xml
@@ -31,34 +31,6 @@
       </key>
    </extension>
    <extension
-         point="org.eclipse.ui.menus">
-      <menuContribution
-            locationURI="menu:org.eclipse.ui.main.menu?after=additions">
-         <menu
-               id="backend_plugin.menus.sampleMenu"
-               label="Sample Menu"
-               mnemonic="M">
-            <command
-                  commandId="backend_plugin.commands.sampleCommand"
-                  id="Plugin_test.menus.sampleCommand"
-                  mnemonic="S">
-            </command>
-         </menu>
-      </menuContribution>
-      <menuContribution
-            locationURI="toolbar:org.eclipse.ui.main.toolbar?after=additions">
-         <toolbar
-               id="backend_plugin.toolbars.sampleToolbar">
-            <command
-                  id="backend_plugin.toolbars.sampleCommand"
-                  commandId="backend_plugin.commands.sampleCommand"
-                  icon="icons/sample.png"
-                  tooltip="Begin tracking changes in current document">
-            </command>
-         </toolbar>
-      </menuContribution>
-   </extension>
-   <extension
          point="org.eclipse.ui.startup">
       <startup
             class="activation.Startup">

--- a/backend_plugin/plugin.xml
+++ b/backend_plugin/plugin.xml
@@ -3,34 +3,6 @@
 <plugin>
 
    <extension
-         point="org.eclipse.ui.commands">
-      <category
-            id="backend_plugin.commands.category"
-            name="Sample Category">
-      </category>
-      <command
-            categoryId="backend_plugin.commands.category"
-            name="Sample Command"
-            id="backend_plugin.commands.sampleCommand">
-      </command>
-   </extension>
-   <extension
-         point="org.eclipse.ui.handlers">
-      <handler
-            class="temp.TrackerStarterTemp"
-            commandId="backend_plugin.commands.sampleCommand">
-      </handler>
-   </extension>
-   <extension
-         point="org.eclipse.ui.bindings">
-      <key
-            commandId="backend_plugin.commands.sampleCommand"
-            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
-            contextId="org.eclipse.ui.contexts.window"
-            sequence="M1+6">
-      </key>
-   </extension>
-   <extension
          point="org.eclipse.ui.startup">
       <startup
             class="activation.Startup">


### PR DESCRIPTION
Removing the toolbar button and menu that were included in the sample plugin package, as our plugin now starts when the FE creates a FeatureSuggestion. I left the startup extension in the plugin.xml file, as we can continue to use this to auto-load our plugin for the purposes of testing on our own. In the future, we will probably want to remove that as evaluation will instead begin when the FE creates a FeatureSuggestion (if we leave it in, there will be a hidden/dummy FeatureSuggestion in the background in addition to the one the FE creates)