### PR TITLE
Refactored code to activate evaluation

### DIFF
--- a/backend_plugin/src/activation/Startup.java
+++ b/backend_plugin/src/activation/Startup.java
@@ -4,7 +4,6 @@ import org.eclipse.ui.IStartup;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
-import org.eclipse.swt.widgets.Display;
 
 import interfaces.FeatureSuggestion;
 
@@ -19,7 +18,8 @@ public class Startup implements IStartup {
 				if (window != null) {
 					// Once we are loaded, make a new FeatureSuggestion
 					// Need to determine how FE will get the FeatureSuggestion object
-					new FeatureSuggestion();
+					FeatureSuggestion fs = new FeatureSuggestion();
+					fs.start();
 				}
 			}
 		});

--- a/backend_plugin/src/evaluators/Evaluator.java
+++ b/backend_plugin/src/evaluators/Evaluator.java
@@ -24,6 +24,8 @@ public class Evaluator {
 
 	private BlockCommentEvaluator blockCommentEval; 
 	private EvaluatorManager em;
+	private IDocument document;
+	private DocumentChangesTracker documentChangesTracker;
 	
 	/**
 	 * Constructs an Evaluator that evaluates the given IEditorPart window
@@ -51,10 +53,12 @@ public class Evaluator {
 		// Get the document stored inside the editor window
 		ITextEditor editor = (ITextEditor) editorWindow;
 		IDocument doc = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+		this.document = doc;
 
 		// Add a DocumentChangesTracker to the document
 		DocumentChangesTracker docTracker = new DocumentChangesTracker(this);
 		doc.addDocumentListener(docTracker);
+		this.documentChangesTracker = docTracker;
 	}
 
 	/**
@@ -67,6 +71,10 @@ public class Evaluator {
 		if (blockCommentEval.evaluate(event)) {
 			this.em.notifyFeatureSuggestion("Block Comment");
 		}
+	}
+
+	public void stop() {
+		this.document.removeDocumentListener(this.documentChangesTracker);
 	}
 	
 }

--- a/backend_plugin/src/evaluators/Evaluator.java
+++ b/backend_plugin/src/evaluators/Evaluator.java
@@ -33,17 +33,13 @@ public class Evaluator {
 	 * @param em EvaluatorManager object that tracks all Evaluator instances
 	 * @param editorWindow the document editor window to add an evaluator to
 	 */
-	public Evaluator(EvaluatorManager em, IEditorPart editorWindow) {
+	public Evaluator(EvaluatorManager em, ITextEditor textEditor) {
 		// DEBUG
 		System.out.println("Evaluator Started");
 
 		this.em = em;
 		blockCommentEval = new BlockCommentEvaluator();
-
-		if (editorWindow instanceof ITextEditor) {
-			ITextEditor textEditor = (ITextEditor) editorWindow;
-			this.initializeListeners(textEditor);
-		}
+		this.initializeListeners(textEditor);
 	}
 
 	/**

--- a/backend_plugin/src/evaluators/Evaluator.java
+++ b/backend_plugin/src/evaluators/Evaluator.java
@@ -26,7 +26,7 @@ public class Evaluator {
 	private EvaluatorManager em;
 	private IDocument document;
 	private DocumentChangesTracker documentChangesTracker;
-	
+
 	/**
 	 * Constructs an Evaluator that evaluates the given IEditorPart window
 	 * under the given EvaluationManager em
@@ -36,10 +36,14 @@ public class Evaluator {
 	public Evaluator(EvaluatorManager em, IEditorPart editorWindow) {
 		// DEBUG
 		System.out.println("Evaluator Started");
-		
+
 		this.em = em;
 		blockCommentEval = new BlockCommentEvaluator();
-		this.initializeListeners(editorWindow);
+
+		if (editorWindow instanceof ITextEditor) {
+			ITextEditor textEditor = (ITextEditor) editorWindow;
+			this.initializeListeners(textEditor);
+		}
 	}
 
 	/**
@@ -48,11 +52,10 @@ public class Evaluator {
 	 * editor window
 	 * @param editorWindow
 	 */
-	private void initializeListeners(IEditorPart editorWindow) {
+	private void initializeListeners(ITextEditor textEditor) {
 
-		// Get the document stored inside the editor window
-		ITextEditor editor = (ITextEditor) editorWindow;
-		IDocument doc = editor.getDocumentProvider().getDocument(editor.getEditorInput());
+		// Get the document stored inside the text editor window
+		IDocument doc = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput());
 		this.document = doc;
 
 		// Add a DocumentChangesTracker to the document

--- a/backend_plugin/src/evaluators/EvaluatorManager.java
+++ b/backend_plugin/src/evaluators/EvaluatorManager.java
@@ -84,7 +84,7 @@ public class EvaluatorManager {
 					if (ePart != null) {
 						IEditorInput eInput = ePart.getEditorInput();
 						if (eInput != null) {
-							java.lang.String filename = eInput.getName();
+							String filename = eInput.getName();
 							if (filename != null && filename.endsWith(".java") &&
 									!this.getOpenEvaluators().containsKey(ePart)) {
 								addEvaluator(ePart);

--- a/backend_plugin/src/interfaces/FeatureSuggestion.java
+++ b/backend_plugin/src/interfaces/FeatureSuggestion.java
@@ -64,6 +64,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	 */
 	@Override
 	public void start() {
+		this.manager.start();
 		isRunning = true;
 		
 		// Debug 
@@ -75,6 +76,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	 */
 	@Override
 	public void stop() {
+		this.manager.stop();
 		isRunning = false;
 		
 		// Debug

--- a/backend_plugin/src/listeners/EditorWindowListener.java
+++ b/backend_plugin/src/listeners/EditorWindowListener.java
@@ -1,10 +1,10 @@
 package listeners;
 
 import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IPartListener2;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.IWorkbenchPartReference;
+import org.eclipse.ui.texteditor.ITextEditor;
 
 import evaluators.EvaluatorManager;
 
@@ -33,16 +33,18 @@ public class EditorWindowListener implements IPartListener2 {
 	 */
 	@Override
 	public void partActivated(IWorkbenchPartReference partRef) {
-		// Called when a window is activated (i.e. user switches to a tab)
 		IWorkbenchPart part = partRef.getPart(false);
-		if (part instanceof IEditorPart) {
-			IEditorPart editor = (IEditorPart) part;
+
+		// If the window is a text editor window
+		if (part instanceof ITextEditor) {
+			ITextEditor editor = (ITextEditor) part;
 			IEditorInput input = editor.getEditorInput();
-			java.lang.String filename = input.getName();		
+			String filename = input.getName();
+
+			// If the document inside the text editor window is a .java file and the
+			// text editor window does not already have an evaluator assigned to it,
+			// Assign an evaluator to the text editor window
 			if (filename.endsWith(".java") && !em.getOpenEvaluators().containsKey(editor)) {
-				// This window is active, but does not yet have an evaluator attached to it.
-				// This might be the case when the user first opens Eclipse, and already has
-				// some open documents
 				em.addEvaluator(editor);
 			}
 		}
@@ -73,15 +75,17 @@ public class EditorWindowListener implements IPartListener2 {
 	 */
 	@Override
 	public void partOpened(IWorkbenchPartReference partRef) {
-		// Called when a window is first opened.
 		IWorkbenchPart part = partRef.getPart(false);
-		if (part instanceof IEditorPart) {
-			IEditorPart editor = (IEditorPart) part;
+
+		// If the window is a text editor window
+		if (part instanceof ITextEditor) {
+			ITextEditor editor = (ITextEditor) part;
 			IEditorInput input = editor.getEditorInput();
-			String filename = input.getName();		
+			String filename = input.getName();
+
+			// If the document inside the text editor window is a .java file,
+			// assign an evaluator to the text editor window
 			if (filename.endsWith(".java")) {
-				// This window is a document editor containing
-				// a Java file, so assign an evaluator to it			
 				em.addEvaluator(editor);
 			}
 		}


### PR DESCRIPTION
Removed auto-activation of evaluation upon creation of a FeatureSuggestion object. Now, listeners will be created and evaluation will start only when FeatureSuggestion.start() is called. Frontend clients can stop evaluation and remove any listeners created by calling FeatureSuggestion.stop()