### PR TITLE
Changed min requirements for running the plugin from Java9 to Java8

### DIFF
--- a/backend_plugin/.classpath
+++ b/backend_plugin/.classpath
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-9">
-		<attributes>
-			<attribute name="module" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/backend_plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/backend_plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,8 +1,8 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=9
-org.eclipse.jdt.core.compiler.compliance=9
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
 org.eclipse.jdt.core.compiler.release=enabled
-org.eclipse.jdt.core.compiler.source=9
+org.eclipse.jdt.core.compiler.source=1.8

--- a/backend_plugin/META-INF/MANIFEST.MF
+++ b/backend_plugin/META-INF/MANIFEST.MF
@@ -12,7 +12,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.ide;bundle-version="3.14.200",
  org.eclipse.jdt.core;bundle-version="3.16.0",
  org.junit
-Bundle-RequiredExecutionEnvironment: JavaSE-9
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Automatic-Module-Name: Plugin_test
 Import-Package: org.eclipse.jface.text
 Export-Package: activation


### PR DESCRIPTION
Changed minimum Java requirements to use the plugin from Java 9 to Java 8. 

This allows more compatibility with front end interfaces. (Specifically the IDE-IT FE).

I didn't manually change any of this code. I edited the build path through the project settings, and then changed the Execution Environment in the Overview panel of the plugin build.properties.

