### PR TITLE
Refactored Block comments and added unit tests

### DIFF
--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -15,6 +15,11 @@ public class BlockCommentEvaluator {
 	private IRegion prevRegion;
 	private int prevOffset;
 	private String prevInsert;
+	private int currentOffset;
+	private String currentInsert;
+
+	private final String SINGLE_SLASH = "/";
+	private final String DOUBLE_SLASH = "//";
 	
 	/**
 	 * Default constructor
@@ -29,78 +34,84 @@ public class BlockCommentEvaluator {
 	 * @return true if the user comments two sequential lines of code, false otherwise
 	 */
 	public boolean evaluate(DocumentEvent event) {
+		// Dev Notes: John
+		// If a user comments out a line with ctrl + /, then the length is 0 and the text is "//"
+	    // A document event can't tell the difference between ctrl + / on two consecutive lines and
+		// commenting out a block of code all at once
+		// ModificationStamp is just a counter that increments. So that's not helpful
 
-		// Took logic Eric created to check for a double back slash
-		// May be a way to optimize this, but it works
-		int currentOffset = event.getOffset();
-		String currentInsert = event.getText();
-		if (prevOffset == currentOffset - 1) {
-			if (currentInsert != null && this.prevInsert != null &&
-					this.prevInsert.equals("/") && currentInsert.equals("/")) {
+		if (doubleBackSlash(event)) {
+			IDocument doc = event.getDocument();
+			try {
+				// Verify that the double slash is at the beginning of the line
+				int lineOffset = doc.getLineInformationOfOffset(currentOffset).getOffset();
+			    String textBeforeSlashes = doc.get(lineOffset, prevOffset-lineOffset);
 
-				// DEBUG
-				System.out.println("Placed two slashes");
+				textBeforeSlashes = textBeforeSlashes.trim();
+				if (textBeforeSlashes.isEmpty()) {
 
-				// Verify that the double backslash is at the start of the line
-				IDocument doc = event.getDocument();
-				try {
-					int lineOffset = doc.getLineInformationOfOffset(currentOffset).getOffset();
-					String textBeforeSlashes = doc.get(lineOffset, prevOffset-lineOffset);
+					// If we have two back slashes, then check if we've found two previously
+					if (firstBackSlashDetected) {
+						IRegion currentRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
 
-					// DEBUG
-					//					System.out.println("line offset: " + lineOffset);
-					//					System.out.println("Prev offset: " + prevOffset);
-					//					System.out.println("Text before slashes: " + textBeforeSlashes);
+						// Check if consecutive lines
+						int prevToCurrentDif = currentRegion.getOffset() - (prevRegion.getOffset() + prevRegion.getLength());
+						int currentToPrevDif = prevRegion.getOffset() - (currentRegion.getOffset() + currentRegion.getLength());
 
-					textBeforeSlashes = textBeforeSlashes.trim();
-					if (textBeforeSlashes.isEmpty()) {
-
-						// DEBUG
-//						System.out.println("Start of line!");
-
-						// If we have two back slashes, then check if we've found two previously
-						if (firstBackSlashDetected) {
-							IRegion currentRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
-
-							// DEBUG
-							// System.out.println("Current Region pos: " + currentRegion.getOffset());
-							// System.out.println("Current REgion length: " + currentRegion.getLength());
-							// System.out.println("Prev Region pos: " + prevRegion.getOffset());
-							// System.out.println("Prev Region length: " + prevRegion.getLength());
-
-							// Check if consecutive lines
-							int prevToCurrentDif = currentRegion.getOffset() - (prevRegion.getOffset() + prevRegion.getLength());
-							int currentToPrevDif = prevRegion.getOffset() - (currentRegion.getOffset() + currentRegion.getLength());
-
-							// Uses a buffer of 2 characters because sometimes IRegion doesn't count the newly inserted "//"
-							if ((prevToCurrentDif >= 0 && prevToCurrentDif <= 2) ||
-									(currentToPrevDif >= 0 && currentToPrevDif <= 2)) {
-								firstBackSlashDetected = false;
-								return true;
-							}
-
-							// If not consecutive, then update prevRegion
+						// Uses a buffer of 2 characters because sometimes IRegion doesn't count the newly inserted "//"
+						if ((prevToCurrentDif >= 0 && prevToCurrentDif <= 2) ||
+								(currentToPrevDif >= 0 && currentToPrevDif <= 2)) {
 							prevRegion = currentRegion;
-
-							// If we haven't seen a double back slash yet
-						} else {
-							firstBackSlashDetected = true;
-							prevRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
+							return true;
 						}
+
+						// If not consecutive, then update prevRegion
+						prevRegion = currentRegion;
+
+						// If we haven't seen a double back slash yet
+					} else {
+						firstBackSlashDetected = true;
+						prevRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
 					}
+				}
 				// Try Catch needed in case offset passed in doc.get methods doesn't actually exist
 				// We shouldn't actually get here, but since it's all asynchronous, something weird may happen
-				} catch (BadLocationException e) {
-					// DEBUG
-					System.out.println("Bad offset location in BlockCommentEvaluator"); // shouldn't be able to get here
-					firstBackSlashDetected = false;
-				}
+			} catch (BadLocationException e) {
+				// DEBUG
+				System.out.println("Bad offset location in BlockCommentEvaluator"); // shouldn't be able to get here
+				firstBackSlashDetected = false;
 			}
 		}
 		// Update the previous event offset and character
 		prevOffset = currentOffset;
 		prevInsert = currentInsert;
 
+		return false;
+	}
+
+	/**
+	 * Helper function that determines if the DocumentEvent(s) provided is a double "//" inputted from the user.
+	 * This will catch both manually typing "/" then "/' as well as using ctrl + / to comment out a single line
+	 * @param event DocumentEvent that occurred
+	 * @return true if a double backslash was placed on a single line, false otherwise
+	 */
+	private boolean doubleBackSlash(DocumentEvent event) {
+		currentOffset = event.getOffset();
+		currentInsert = event.getText();
+
+		// Currently checking for consecutive ctrl + / has limitations with Eclipse API
+		// Check if a "//" was added through copy/paste or ctrl + /
+//		if (event.getText().equals(DOUBLE_SLASH)) {
+//			return true;
+//		}
+
+		// Check if there was a single "/" typed followed by another "/"
+		if (prevOffset == currentOffset - 1) {
+			if (currentInsert != null && this.prevInsert != null &&
+					this.prevInsert.equals(SINGLE_SLASH) && currentInsert.equals(SINGLE_SLASH)) {
+				return true;
+			}
+		}
 		return false;
 	}
 }

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -45,7 +45,7 @@ public class BlockCommentEvaluator {
 			try {
 				// Verify that the double slash is at the beginning of the line
 				int lineOffset = doc.getLineInformationOfOffset(currentOffset).getOffset();
-			    String textBeforeSlashes = doc.get(lineOffset, prevOffset-lineOffset);
+				String textBeforeSlashes = doc.get(lineOffset, prevOffset-lineOffset);
 
 				textBeforeSlashes = textBeforeSlashes.trim();
 				if (textBeforeSlashes.isEmpty()) {

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -36,7 +36,7 @@ public class BlockCommentEvaluator {
 	public boolean evaluate(DocumentEvent event) {
 		// Dev Notes: John
 		// If a user comments out a line with ctrl + /, then the length is 0 and the text is "//"
-	    // A document event can't tell the difference between ctrl + / on two consecutive lines and
+		// A document event can't tell the difference between ctrl + / on two consecutive lines and
 		// commenting out a block of code all at once
 		// ModificationStamp is just a counter that increments. So that's not helpful
 
@@ -101,9 +101,9 @@ public class BlockCommentEvaluator {
 
 		// Currently checking for consecutive ctrl + / has limitations with Eclipse API
 		// Check if a "//" was added through copy/paste or ctrl + /
-//		if (event.getText().equals(DOUBLE_SLASH)) {
-//			return true;
-//		}
+		// if (event.getText().equals(DOUBLE_SLASH)) {
+		//	 return true;
+		// }
 
 		// Check if there was a single "/" typed followed by another "/"
 		if (prevOffset == currentOffset - 1) {

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -74,8 +74,8 @@ public class BlockCommentEvaluator {
 						prevRegion = event.getDocument().getLineInformationOfOffset(currentOffset);
 					}
 				}
-				// Try Catch needed in case offset passed in doc.get methods doesn't actually exist
-				// We shouldn't actually get here, but since it's all asynchronous, something weird may happen
+			// Try Catch needed in case offset passed in doc.get methods doesn't actually exist
+			// We shouldn't actually get here, but since it's all asynchronous, something weird may happen
 			} catch (BadLocationException e) {
 				// DEBUG
 				System.out.println("Bad offset location in BlockCommentEvaluator"); // shouldn't be able to get here

--- a/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
+++ b/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
@@ -1,4 +1,4 @@
-package test.java;
+package test.falseNegatives.evaluators;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -14,16 +14,17 @@ import org.junit.Test;
 import main.evaluators.BlockCommentEvaluator;
 
 /**
- * Unit test for BlockCommentEvaluator
+ * Tests against all known sequences of actions a user can take to manually attempt to comment out multiple lines
+ * of code in their document
  */
-public class BlockCommentEvaluatorTest {
+public class BlockCommentFalseNegativeTest {
 	
 	private static final String content = "Line1\n Line2\n Line3\n";
 	private static final String SINGLE_SLASH = "/";
-
+	
 	private IDocument doc;
 	private BlockCommentEvaluator testEvaluator;
-
+	
 	// Used to store mock event data
 	private DocumentEvent event;
 	private int offset;
@@ -37,7 +38,7 @@ public class BlockCommentEvaluatorTest {
 		doc = new Document(content);
 		testEvaluator = new BlockCommentEvaluator();
 	}
-
+	
 	/**
 	 * Tests the block comment evaluation function returns true when line 0 then line 1 of a document are commented out
 	 */
@@ -77,7 +78,6 @@ public class BlockCommentEvaluatorTest {
 	 */
 	@Test
 	public void twoConsecutiveLinesUpCommentedOut() {
-		
 		// Create mock document event changes
 		try {
 			// Mock a document event with a single backslash placed at the beginning of the third line
@@ -120,7 +120,7 @@ public class BlockCommentEvaluatorTest {
 		event = createDocEvent(offset, SINGLE_SLASH);
 		assertFalse(testEvaluator.evaluate(event));
 		// Place a second backslash after the first
-
+		
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
 		assertFalse(testEvaluator.evaluate(event));
@@ -201,11 +201,10 @@ public class BlockCommentEvaluatorTest {
 	}
 
 	/**
-	 * Verifies that the evaluation function will not trigger when the user types "//" anywhere but the start
-	 * of a line
+	 * Tests for /// one one line, then // on the next line
 	 */
 	@Test
-	public void commentNotAtStartOfLineDown() {
+	public void threeSlashesConsecutiveLinesDown() {
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
@@ -214,33 +213,35 @@ public class BlockCommentEvaluatorTest {
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
 		assertFalse(testEvaluator.evaluate(event));
+		// Place a third backslash after the second
+		offset++;
+		event = createDocEvent(offset, SINGLE_SLASH);
+		assertFalse(testEvaluator.evaluate(event));
 
+		// Pull the offset for the start of the second line so we aren't guessing
 		try {
-			// Pull the offset for the start of the second line so we aren't guessing
+			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
-			// Add two to the offset so we're in the middle of the line
-			offset += 2;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			assertFalse(testEvaluator.evaluate(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
-			// Now the evaluation function should not trigger
-			assertFalse(testEvaluator.evaluate(event));
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
 			e.printStackTrace();
 		}
 	}
-
+	
 	/**
-	 * Verifies that the evaluation function will not trigger when the user types "//" anywhere but the start
-	 * of a line
+	 * Tests for /// one one line, then // on the previous line
 	 */
 	@Test
-	public void commentNotAtStartOfLineUp() {
+	public void threeSlashesConsecutiveLinesUp() {
 		try {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
@@ -252,10 +253,13 @@ public class BlockCommentEvaluatorTest {
 			event = createDocEvent(offset, SINGLE_SLASH);
 			assertFalse(testEvaluator.evaluate(event));
 
+			// Place a third backslash after the second
+			offset++;
+			event = createDocEvent(offset, SINGLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+			
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
-			// Add two to get to mid line
-			offset += 2;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			assertFalse(testEvaluator.evaluate(event));
 
@@ -263,14 +267,14 @@ public class BlockCommentEvaluatorTest {
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertFalse(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluate(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
 			e.printStackTrace();
 		}
 	}
-
+	
 	/**
 	 * Helper method to create a new document event given the offset and text to be added
 	 * @param offset position in the document to add the text
@@ -279,5 +283,5 @@ public class BlockCommentEvaluatorTest {
 	 */
 	private DocumentEvent createDocEvent(int offset, String text) {
 		return new DocumentEvent(doc, offset, text.length(), text);
-	}
+	} 
 }

--- a/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
+++ b/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
@@ -21,6 +21,7 @@ public class BlockCommentFalseNegativeTest {
 	
 	private static final String content = "Line1\n Line2\n Line3\n";
 	private static final String SINGLE_SLASH = "/";
+	private static final String DOUBLE_SLASH = "//";
 	
 	private IDocument doc;
 	private BlockCommentEvaluator testEvaluator;
@@ -44,7 +45,6 @@ public class BlockCommentFalseNegativeTest {
 	 */
 	@Test
 	public void twoConsecutiveLinesDownCommentedOut() {
-
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
@@ -265,6 +265,120 @@ public class BlockCommentFalseNegativeTest {
 
 			// Place another backslash after the previous one
 			offset++;
+			event = createDocEvent(offset, SINGLE_SLASH);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * Tests if a user inserts "//" on one line then "//" on the next line
+	 * This can be accomplished by the user through ctrl + / on each line or if they paste a "//"
+	 */
+	@Test
+	public void doubleSlashConsecutiveDown() {
+		// Mock a document event with a double backslash placed at the beginning of the first line
+		offset = 0;
+		event = createDocEvent(offset, DOUBLE_SLASH);
+		assertFalse(testEvaluator.evaluate(event));
+
+		// Pull the offset for the start of the second line so we aren't guessing
+		try {
+			// Place a single backslash at the start of the second line
+			offset = doc.getLineOffset(1);
+			event = createDocEvent(offset, DOUBLE_SLASH);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * Tests if a user inserts "//" on one line then "//" on the next line
+	 * This can be accomplished by the user through ctrl + / on each line or if they paste a "//"
+	 */
+	@Test
+	public void doubleSlashConsecutiveUp() {
+		try {
+			// Mock a document event with a double backslash placed at the beginning of the third line
+			offset = doc.getLineOffset(2);
+			event = createDocEvent(offset, DOUBLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Mock a document event with a double backslash placed at the beginning of the second line
+			offset = doc.getLineOffset(1);
+			event = createDocEvent(offset, DOUBLE_SLASH);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
+			e.printStackTrace();
+		}
+	}
+	
+	/**
+	 * Tests if a user inserts "/", the places another "/" in front of the first slash on one line, and 
+	 * repeats this behavior on the next line
+	 */
+	@Test
+	public void singleSlashMoveLeftSingleSlashConsecutiveLinesDown() {
+		// Mock a document event with a single backslash placed at the beginning of the first line
+		offset = 0;
+		event = createDocEvent(offset, SINGLE_SLASH);
+		assertFalse(testEvaluator.evaluate(event));
+		// Place a second backslash at the beginning of the line
+		event = createDocEvent(offset, SINGLE_SLASH);
+		assertFalse(testEvaluator.evaluate(event));
+		
+		// Pull the offset for the start of the second line so we aren't guessing
+		try {
+			// Place a single backslash at the start of the second line
+			offset = doc.getLineOffset(1);
+			event = createDocEvent(offset, SINGLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+			
+			// Place another backslash at the start of the line
+			event = createDocEvent(offset, SINGLE_SLASH);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Tests if a user inserts "/", the places another "/" in front of the first slash on one line, and 
+	 * repeats this behavior on the previous line
+	 */
+	@Test
+	public void singleSlashMoveLeftSingleSlashConsecutiveLinesUp() {
+		// Create mock document event changes
+		try {
+			// Mock a document event with a single backslash placed at the beginning of the third line
+			offset = doc.getLineOffset(2);
+			event = createDocEvent(offset, SINGLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+		
+			// Place a second backslash at the start of the same line
+			event = createDocEvent(offset, SINGLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+		
+			// Mock a document event with a single backslash placed at the beginning of the second line
+			offset = doc.getLineOffset(1);
+			event = createDocEvent(offset, SINGLE_SLASH);
+			assertFalse(testEvaluator.evaluate(event));
+			
+			// Place another backslash at the start of the second line
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluate(event));

--- a/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
@@ -23,7 +23,7 @@ public class BlockCommentEvaluatorTest {
 	 * Tests the block comment evaluation function returns true when line 0 then line 1 of a document are commented out
 	 */
 	@Test
-	public void consecutiveLinesDownCommentedOut() {
+	public void twoConsecutiveLinesDownCommentedOut() {
 		int offset;
 		int length;
 		String textAdded;
@@ -34,7 +34,7 @@ public class BlockCommentEvaluatorTest {
 		IDocument doc = new Document(content);
 		
 		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
-		
+
 		// Send mock data
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
@@ -71,7 +71,7 @@ public class BlockCommentEvaluatorTest {
 	 * Tests the block comment evaluation function returns true when line 2 then line 1 of a document are commented out
 	 */
 	@Test
-	public void consecutiveLinesUpCommentedOut() {
+	public void twoConsecutiveLinesUpCommentedOut() {
 		int offset;
 		int length;
 		String textAdded;
@@ -106,6 +106,229 @@ public class BlockCommentEvaluatorTest {
 			event = new DocumentEvent(doc, offset, length, textAdded);
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
+			fail("BadLocationException thrown in consecutiveLinesUpCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Verify that evaluation function triggers if two consecutive lines are commented out and triggers again
+	 * if another consecutive line is triggered
+	 */
+	@Test
+	public void threeConsecutiveLinesDownCommented() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+
+		// Send mock data
+		// Mock a document event with a single backslash placed at the beginning of the first line
+		offset = 0;
+		length = 1;
+		textAdded = "/";
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+		// Place a second backslash after the first
+		offset++;
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+
+		// Pull the offset for the start of the second line so we aren't guessing
+		try {
+			// Place a single backslash at the start of the second line
+			offset = doc.getLineOffset(1);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
+			fail("BadLocationException thrown in consecutiveLinesDownCommentedOut Test");
+			e.printStackTrace();
+		}
+
+		// Comment out the third line
+		try {
+			// Place a single backslash at the start of the third line
+			offset = doc.getLineOffset(2);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
+			fail("BadLocationException thrown in consecutiveLinesDownCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Tests the block comment evaluation function returns true when line 3 then line 2 then line 1 are commented out
+	 */
+	@Test
+	public void threeConsecutiveLinesUpCommentedOut() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+		length = 1;
+		textAdded = "/";
+		// Create mock document event changes
+		try {
+			// Mock a document event with a single backslash placed at the beginning of the third line
+			offset = doc.getLineOffset(2);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place a second backslash after the first
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Mock a document event with a single backslash placed at the beginning of the second line
+			offset = doc.getLineOffset(1);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+
+			// Mock a document event with a single backslash placed at the beginning of the first line
+			offset = doc.getLineOffset(0);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertTrue(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
+			fail("BadLocationException thrown in consecutiveLinesUpCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Verifies that the evaluation function will not trigger when the user types "//" anywhere but the start
+	 * of a line
+	 */
+	@Test
+	public void commentNotAtStartOfLineDown() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+
+		// Send mock data
+		// Mock a document event with a single backslash placed at the beginning of the first line
+		offset = 0;
+		length = 1;
+		textAdded = "/";
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+		// Place a second backslash after the first
+		offset++;
+		event = new DocumentEvent(doc, offset, length, textAdded);
+		assertFalse(testEvaluator.evaluate(event));
+
+		try {
+			// Pull the offset for the start of the second line so we aren't guessing
+			offset = doc.getLineOffset(1);
+			// Add two to the offset so we're in the middle of the line
+			offset += 2;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+
+			// Now the evaluation function should not trigger
+			assertFalse(testEvaluator.evaluate(event));
+		} catch (BadLocationException e) {
+			// Should never get here
+			// fail included as sanity check
+			fail("BadLocationException thrown in consecutiveLinesDownCommentedOut Test");
+			e.printStackTrace();
+		}
+	}
+
+	/**
+	 * Verifies that the evaluation function will not trigger when the user types "//" anywhere but the start
+	 * of a line
+	 */
+	@Test
+	public void commentNotAtStartOfLineUp() {
+		int offset;
+		int length;
+		String textAdded;
+		DocumentEvent event;
+
+		// Create a document with four lines
+		// Line count starts at 0
+		IDocument doc = new Document(content);
+		BlockCommentEvaluator testEvaluator = new BlockCommentEvaluator();
+		length = 1;
+		textAdded = "/";
+		// Create mock document event changes
+		try {
+			// Mock a document event with a single backslash placed at the beginning of the third line
+			offset = doc.getLineOffset(2);
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place a second backslash after the first
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Mock a document event with a single backslash placed at the beginning of the second line
+			offset = doc.getLineOffset(1);
+			// Add two to get to mid line
+			offset += 2;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			assertFalse(testEvaluator.evaluate(event));
+
+			// Place another backslash after the previous one
+			offset++;
+			event = new DocumentEvent(doc, offset, length, textAdded);
+			// Now the evaluation function should trigger
+			assertFalse(testEvaluator.evaluate(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			// fail included as sanity check


### PR DESCRIPTION
Refined the block comment evaluation again.

Refactored some of it in anticipation of checking for ctrl + / on consecutive lines. However, there are limitations on the Eclipse API functionality.

If someone ctrl + / two consecutive lines, it looks exactly the same as if something ctrl + / both those lines at the same time. We either need a workaround or just accept this limitation.

Also added a few more unit tests.