### PR TITLE
Renamed DocumentChangesTracker to DocumentChangesListener

### DIFF
--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -29,7 +29,7 @@ public class Evaluator {
 	private RemoveImportEvaluator removeImportEval;
 
 	private IDocument document;
-	private DocumentChangesListener documentChangesTracker;
+	private DocumentChangesListener documentChangesListener;
 	
 	private IAnnotationModel annotationModel;
 	private AnnotationModelListener annotationModelListener;
@@ -63,9 +63,9 @@ public class Evaluator {
 		this.document = doc;
 
 		// Add a DocumentChangesTracker to the document
-		DocumentChangesListener docTracker = new DocumentChangesListener(this);
-		doc.addDocumentListener(docTracker);
-		this.documentChangesTracker = docTracker;
+		DocumentChangesListener docListener = new DocumentChangesListener(this);
+		doc.addDocumentListener(docListener);
+		this.documentChangesListener = docListener;
 		
 		// Create a new AnnotationModelListener
 		this.annotationModelListener = new AnnotationModelListener(this);
@@ -96,7 +96,7 @@ public class Evaluator {
 	}
 
 	public void stop() {
-		this.document.removeDocumentListener(this.documentChangesTracker);
+		this.document.removeDocumentListener(this.documentChangesListener);
 		this.annotationModel.removeAnnotationModelListener(this.annotationModelListener);
 	}
 	

--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -5,7 +5,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
 
-import main.listeners.DocumentChangesTracker;
+import main.listeners.DocumentChangesListener;
 import main.listeners.AnnotationModelListener;
 
 
@@ -29,7 +29,7 @@ public class Evaluator {
 	private RemoveImportEvaluator removeImportEval;
 
 	private IDocument document;
-	private DocumentChangesTracker documentChangesTracker;
+	private DocumentChangesListener documentChangesTracker;
 	
 	private IAnnotationModel annotationModel;
 	private AnnotationModelListener annotationModelListener;
@@ -63,7 +63,7 @@ public class Evaluator {
 		this.document = doc;
 
 		// Add a DocumentChangesTracker to the document
-		DocumentChangesTracker docTracker = new DocumentChangesTracker(this);
+		DocumentChangesListener docTracker = new DocumentChangesListener(this);
 		doc.addDocumentListener(docTracker);
 		this.documentChangesTracker = docTracker;
 		

--- a/backend_plugin/src/main/listeners/DocumentChangesListener.java
+++ b/backend_plugin/src/main/listeners/DocumentChangesListener.java
@@ -12,11 +12,11 @@ import main.evaluators.Evaluator;
  * are detected, evaluation will be run on the changes to see if any Eclipse
  * features were "triggered"
  */
-public class DocumentChangesTracker implements IDocumentListener {
+public class DocumentChangesListener implements IDocumentListener {
 	
 	private Evaluator evaluator;
 	
-	public DocumentChangesTracker(Evaluator evaluator) {
+	public DocumentChangesListener(Evaluator evaluator) {
 		super();
 		this.evaluator = evaluator;
 	}


### PR DESCRIPTION
This way we aren't mixing up the terms listener/tracker. I think listener makes more sense for these classes.