### PR TITLE
Created an abstract class for feature evaluators

### DIFF
--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -4,15 +4,12 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
-import org.eclipse.jface.text.source.IAnnotationModel;
 
 /**
  * Evaluates DocumentEvent changes to determine if the user is commenting out multiple sequential lines of code. If so,
  * then the user should be notified of the block comment feature in Eclipse.
  */
-public class BlockCommentEvaluator implements FeatureEvaluator {
-		
-	final String FEATURE_ID = "blockCommentSuggestion";
+public class BlockCommentEvaluator extends FeatureEvaluator {
 
 	private boolean firstBackSlashDetected;
 	private IRegion prevRegion;
@@ -23,6 +20,7 @@ public class BlockCommentEvaluator implements FeatureEvaluator {
 	 * Default constructor
 	 */
 	public BlockCommentEvaluator() {
+		this.featureID = "blockCommentSuggestion";
 		firstBackSlashDetected = false;
 	}
 	
@@ -105,23 +103,5 @@ public class BlockCommentEvaluator implements FeatureEvaluator {
 		prevInsert = currentInsert;
 
 		return false;
-	}
-	
-	/**
-	 * Evaluates changes to the annotation model in regards to the block
-	 * commenting feature
-	 */
-	public boolean evaluateAnnotationModelChanges(IAnnotationModel model) {
-		
-		// TODO: Investigate ways to incorporate annotation model changes into the
-		// remove import evaluation if needed
-		return false;
-	}
-
-	/**
-	 * Returns the feature ID for the block commenting feature
-	 */
-	public String getFeatureID() {
-		return this.FEATURE_ID;
 	}
 }

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -4,12 +4,13 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.source.IAnnotationModel;
 
 /**
  * Evaluates DocumentEvent changes to determine if the user is commenting out multiple sequential lines of code. If so,
  * then the user should be notified of the block comment feature in Eclipse.
  */
-public class BlockCommentEvaluator {
+public class BlockCommentEvaluator implements FeatureEvaluator {
 		
 	private boolean firstBackSlashDetected;
 	private IRegion prevRegion;
@@ -28,7 +29,7 @@ public class BlockCommentEvaluator {
 	 * @param event the change detected by the DocumentChange Listener
 	 * @return true if the user comments two sequential lines of code, false otherwise
 	 */
-	public boolean evaluate(DocumentEvent event) {
+	public boolean evaluateDocumentChanges(DocumentEvent event) {
 
 		// Took logic Eric created to check for a double back slash
 		// May be a way to optimize this, but it works
@@ -102,5 +103,23 @@ public class BlockCommentEvaluator {
 		prevInsert = currentInsert;
 
 		return false;
+	}
+	
+	/**
+	 * Evaluates changes to the annotation model in regards to the block
+	 * commenting feature
+	 */
+	public boolean evaluateAnnotationModelChanges(IAnnotationModel model) {
+		
+		// TODO: Investigate ways to incorporate annotation model changes into the
+		// remove import evaluation if needed
+		return false;
+	}
+	
+	/**
+	 * Returns the feature ID for the block commenting feature
+	 */
+	public String getFeatureID() {
+		return "blockCommentSuggestion";
 	}
 }

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -12,6 +12,8 @@ import org.eclipse.jface.text.source.IAnnotationModel;
  */
 public class BlockCommentEvaluator implements FeatureEvaluator {
 		
+	final String FEATURE_ID = "blockCommentSuggestion";
+
 	private boolean firstBackSlashDetected;
 	private IRegion prevRegion;
 	private int prevOffset;
@@ -115,11 +117,11 @@ public class BlockCommentEvaluator implements FeatureEvaluator {
 		// remove import evaluation if needed
 		return false;
 	}
-	
+
 	/**
 	 * Returns the feature ID for the block commenting feature
 	 */
 	public String getFeatureID() {
-		return "blockCommentSuggestion";
+		return this.FEATURE_ID;
 	}
 }

--- a/backend_plugin/src/main/evaluators/FeatureEvaluator.java
+++ b/backend_plugin/src/main/evaluators/FeatureEvaluator.java
@@ -3,7 +3,9 @@ package main.evaluators;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.source.IAnnotationModel;
 
-public interface FeatureEvaluator {
+public abstract class FeatureEvaluator {
+
+	protected String featureID;
 
 	/**
 	 * Evaluates changes made to the text within a document
@@ -11,7 +13,9 @@ public interface FeatureEvaluator {
 	 * @return boolean true if the document changes cause the feature to be
 	 *					triggered; false otherwise
 	 */
-	public boolean evaluateDocumentChanges(DocumentEvent docEvent);
+	public boolean evaluateDocumentChanges(DocumentEvent docEvent) {
+		return false;
+	}
 	
 	/**
 	 * Evaluates changes to the annotation model of a document/editor window
@@ -20,10 +24,14 @@ public interface FeatureEvaluator {
 	 * @return boolean true if the annotation model changes cause the feature
 	 * 					to be triggered; false otherwise
 	 */
-	public boolean evaluateAnnotationModelChanges(IAnnotationModel model);
+	public boolean evaluateAnnotationModelChanges(IAnnotationModel model) {
+		return false;
+	}
 	
 	/**
 	 * @return The String representing the unique feature ID of this feature
 	 */
-	public String getFeatureID();
+	public String getFeatureID() {
+		return this.featureID;
+	}
 }

--- a/backend_plugin/src/main/evaluators/FeatureEvaluator.java
+++ b/backend_plugin/src/main/evaluators/FeatureEvaluator.java
@@ -1,0 +1,29 @@
+package main.evaluators;
+
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.source.IAnnotationModel;
+
+public interface FeatureEvaluator {
+
+	/**
+	 * Evaluates changes made to the text within a document
+	 * @param docEvent The information about the changes that were made
+	 * @return boolean true if the document changes cause the feature to be
+	 *					triggered; false otherwise
+	 */
+	public boolean evaluateDocumentChanges(DocumentEvent docEvent);
+	
+	/**
+	 * Evaluates changes to the annotation model of a document/editor window
+	 * @param model The information about the annotations in the
+	 * 					document/editor window
+	 * @return boolean true if the annotation model changes cause the feature
+	 * 					to be triggered; false otherwise
+	 */
+	public boolean evaluateAnnotationModelChanges(IAnnotationModel model);
+	
+	/**
+	 * @return The String representing the unique feature ID of this feature
+	 */
+	public String getFeatureID();
+}

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -1,6 +1,8 @@
 package main.evaluators;
 
 import java.util.Iterator;
+
+import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -10,7 +12,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  * statements are found, then evaluate will return true
  *
  */
-public class RemoveImportEvaluator {
+public class RemoveImportEvaluator implements FeatureEvaluator {
 	
 	
 	ITextEditor editor;
@@ -24,12 +26,23 @@ public class RemoveImportEvaluator {
 	}
 	
 	/**
+	 * Evaluates changes to the document text in regards to the remove import
+	 * feature
+	 */
+	public boolean evaluateDocumentChanges(DocumentEvent event) {
+		
+		// TODO: Investigate ways to incorporate document changes into the
+		// remove import evaluation if needed
+		return false;
+	}
+	
+	/**
 	 * Checks the document that matches the docName to see if there are any unused import statements
 	 * 
 	 * @param event
 	 * @return true if there are unused import statements in the document, false otherwise
 	 */
-	public boolean evaluate(IAnnotationModel model) {
+	public boolean evaluateAnnotationModelChanges(IAnnotationModel model) {
 		
 		// Dev notes: John
 		// String matching isn't ideal in this case, but it's the most reliable.
@@ -48,4 +61,7 @@ public class RemoveImportEvaluator {
 		return false;
 	}
 	
+	public String getFeatureID() {
+		return "removeUnusedImportStatementsSuggestion";
+	}
 }

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -2,7 +2,6 @@ package main.evaluators;
 
 import java.util.Iterator;
 
-import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -12,9 +11,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  * statements are found, then evaluate will return true
  *
  */
-public class RemoveImportEvaluator implements FeatureEvaluator {
-	
-	final String FEATURE_ID = "removeUnusedImportStatementsSuggestion";
+public class RemoveImportEvaluator extends FeatureEvaluator {
 	
 	ITextEditor editor;
 	
@@ -23,18 +20,8 @@ public class RemoveImportEvaluator implements FeatureEvaluator {
 	 * @param docName the name of the document this evaluator is attached to
 	 */
 	public RemoveImportEvaluator(ITextEditor editor) {
+		this.featureID = "removeUnusedImportStatementsSuggestion";
 		this.editor = editor;
-	}
-	
-	/**
-	 * Evaluates changes to the document text in regards to the remove import
-	 * feature
-	 */
-	public boolean evaluateDocumentChanges(DocumentEvent event) {
-		
-		// TODO: Investigate ways to incorporate document changes into the
-		// remove import evaluation if needed
-		return false;
 	}
 	
 	/**
@@ -51,7 +38,7 @@ public class RemoveImportEvaluator implements FeatureEvaluator {
 		// updated upon saves. The annotation is updated upon document changes.
 		
 		Iterator<Annotation> it = model.getAnnotationIterator();
-		
+
 		while (it.hasNext()) {
 			Annotation current = it.next();
 			// Check if the annotation is an unused import
@@ -60,9 +47,5 @@ public class RemoveImportEvaluator implements FeatureEvaluator {
 			}
 		}
 		return false;
-	}
-	
-	public String getFeatureID() {
-		return this.FEATURE_ID;
 	}
 }

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -14,6 +14,7 @@ import org.eclipse.ui.texteditor.ITextEditor;
  */
 public class RemoveImportEvaluator implements FeatureEvaluator {
 	
+	final String FEATURE_ID = "removeUnusedImportStatementsSuggestion";
 	
 	ITextEditor editor;
 	
@@ -62,6 +63,6 @@ public class RemoveImportEvaluator implements FeatureEvaluator {
 	}
 	
 	public String getFeatureID() {
-		return "removeUnusedImportStatementsSuggestion";
+		return this.FEATURE_ID;
 	}
 }

--- a/backend_plugin/src/main/listeners/DocumentChangesTracker.java
+++ b/backend_plugin/src/main/listeners/DocumentChangesTracker.java
@@ -27,9 +27,6 @@ public class DocumentChangesTracker implements IDocumentListener {
 	 */
 	@Override
 	public void documentAboutToBeChanged(DocumentEvent event) {
-		// Not sure if it matters whether we use this method
-		// or documentChanged to track input, we will find out
-		// over time I suppose. For now I'm just keeping it blank
 	}
 
 	/**
@@ -39,11 +36,7 @@ public class DocumentChangesTracker implements IDocumentListener {
 	@Override
 	public void documentChanged(DocumentEvent event) {
 		
-		// event has options like getText() to get the text that was added
-		// or removed from the document, getOffset() to get the offset in
-		// the document where the insertion/removal occured, etc.
-		
-		// send event to the Evaluator
-		evaluator.evaluateDocChanges(event);
+		// Send the document change event information to the Evaluator
+		evaluator.evaluateDocumentChanges(event);
 	}
 }

--- a/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
+++ b/backend_plugin/src/test/falseNegatives/evaluators/BlockCommentFalseNegativeTest.java
@@ -48,24 +48,24 @@ public class BlockCommentFalseNegativeTest {
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a second backslash after the first
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
 			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -83,23 +83,23 @@ public class BlockCommentFalseNegativeTest {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Place a second backslash after the first
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -118,37 +118,37 @@ public class BlockCommentFalseNegativeTest {
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a second backslash after the first
 		
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
 			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 
 			// Comment out the third line
 			// Place a single backslash at the start of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -165,34 +165,34 @@ public class BlockCommentFalseNegativeTest {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place a second backslash after the first
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 
 			// Mock a document event with a single backslash placed at the beginning of the first line
 			offset = doc.getLineOffset(0);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -208,28 +208,28 @@ public class BlockCommentFalseNegativeTest {
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a second backslash after the first
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a third backslash after the second
 		offset++;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
 			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -246,28 +246,28 @@ public class BlockCommentFalseNegativeTest {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place a second backslash after the first
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place a third backslash after the second
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Place another backslash after the previous one
 			offset++;
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -284,7 +284,7 @@ public class BlockCommentFalseNegativeTest {
 		// Mock a document event with a double backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, DOUBLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
@@ -292,7 +292,7 @@ public class BlockCommentFalseNegativeTest {
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, DOUBLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -310,13 +310,13 @@ public class BlockCommentFalseNegativeTest {
 			// Mock a document event with a double backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, DOUBLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 
 			// Mock a document event with a double backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, DOUBLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -333,22 +333,22 @@ public class BlockCommentFalseNegativeTest {
 		// Mock a document event with a single backslash placed at the beginning of the first line
 		offset = 0;
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a second backslash at the beginning of the line
 		event = createDocEvent(offset, SINGLE_SLASH);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
 			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash at the start of the line
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());
@@ -367,21 +367,21 @@ public class BlockCommentFalseNegativeTest {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Place a second backslash at the start of the same line
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = createDocEvent(offset, SINGLE_SLASH);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash at the start of the second line
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			fail("Should never see this error in: " + this.getClass().getSimpleName() + "::" + this.getClass().getName());

--- a/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
@@ -41,24 +41,24 @@ public class BlockCommentEvaluatorTest {
 		length = 1;
 		textAdded = "/";
 		event = new DocumentEvent(doc, offset, length, textAdded);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		// Place a second backslash after the first
 		offset++;
 		event = new DocumentEvent(doc, offset, length, textAdded);
-		assertFalse(testEvaluator.evaluate(event));
+		assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 		// Pull the offset for the start of the second line so we aren't guessing
 		try {
 			// Place a single backslash at the start of the second line
 			offset = doc.getLineOffset(1);
 			event = new DocumentEvent(doc, offset, length, textAdded);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash after the previous one
 			offset++;
 			event = new DocumentEvent(doc, offset, length, textAdded);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			// fail included as sanity check
@@ -89,23 +89,23 @@ public class BlockCommentEvaluatorTest {
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);
 			event = new DocumentEvent(doc, offset, length, textAdded);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Place a second backslash after the first
 			offset++;
 			event = new DocumentEvent(doc, offset, length, textAdded);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 		
 			// Mock a document event with a single backslash placed at the beginning of the second line
 			offset = doc.getLineOffset(1);
 			event = new DocumentEvent(doc, offset, length, textAdded);
-			assertFalse(testEvaluator.evaluate(event));
+			assertFalse(testEvaluator.evaluateDocumentChanges(event));
 			
 			// Place another backslash after the previous one
 			offset++;
 			event = new DocumentEvent(doc, offset, length, textAdded);
 			// Now the evaluation function should trigger
-			assertTrue(testEvaluator.evaluate(event));
+			assertTrue(testEvaluator.evaluateDocumentChanges(event));
 		} catch (BadLocationException e) {
 			// Should never get here
 			// fail included as sanity check


### PR DESCRIPTION
-Created FeatureEvaluator as an interface that all feature evaluators can implement
-Refactored existing feature evaluators to implement the interface (did not change underlying evaluation)

UPDATE:
-Changed the interface to an abstract class instead. The abstract class makes more sense as each evaluator function shares some identical functionality (i.e. returning its featureID from the getFeatureID() method), and also so that we can declare default functionality for the evaluateDocumentChanges or evaluateAnnotationModelChanges, rather than implementing the same default functionality in each subclass individually