### PR TITLE
Added evaluator for trailing white space removal

### DIFF
--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -58,6 +58,7 @@ public class Evaluator {
 		this.featureEvaluators.add(new RemoveImportEvaluator(textEditor));
 		this.featureEvaluators.add(new AddImportEvaluator(this.document));
 		this.featureEvaluators.add(new CorrectIndentationEvaluator(this.document));
+		this.featureEvaluators.add(new TrailingWhiteSpaceEvaluator(this.document));
 	}
 
 	/**

--- a/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
+++ b/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
@@ -1,0 +1,68 @@
+package main.evaluators;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
+
+/**
+ * Evaluates DocumentEvent changes to determine if the user is manually deleting trailing white spaces
+ * Eclipse has a setting to automatically remove trailing white spaces on save, so the user could use
+ * this instead.
+ */
+public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
+	
+	private String lineBeforeChange;
+	
+	/**
+	 * Constructs a TrailingWhiteSpaceEvaluator
+	 * @param document
+	 */
+	public TrailingWhiteSpaceEvaluator(IDocument document) {
+		this.featureID = "trailingWhiteSpaceSuggestion";
+		this.document = document;
+	}
+
+	/**
+	 * Evaluates document changes to see if the user is manually deleting all trailing white space
+	 * from a line
+	 * @param event
+	 */
+	@Override
+	public boolean evaluateDocumentChanges(DocumentEvent event) {
+		
+		try {
+			int line = document.getLineOfOffset(event.getOffset());
+			int startOffset = document.getLineOffset(line);
+			int length = document.getLineLength(line);
+			
+			// Need to check up to length - 1 instead of length due to line feed char at end
+			String lineAfterChange = document.get(startOffset, length - 1);
+			
+			// Check that only the line's whitespace has changed, and that the line no longer
+			// ends with whitespace
+			boolean nonWhiteSpaceCharactersUnchanged = lineBeforeChange.trim().equals(lineAfterChange.trim());
+			boolean trailingWhiteSpaceBefore = lineBeforeChange.endsWith(" ") || lineBeforeChange.endsWith("\t");
+			boolean trailingWhiteSpaceAfter = lineAfterChange.endsWith(" ") || lineAfterChange.endsWith("\t");		
+			return nonWhiteSpaceCharactersUnchanged && trailingWhiteSpaceBefore && !trailingWhiteSpaceAfter;	
+		} catch (BadLocationException e) {
+		}
+		return false;
+	}
+
+	/**
+	 * Stores the contents of the line before document changes are made
+	 */
+	@Override
+	public boolean evaluateDocumentBeforeChange(DocumentEvent event) {
+		try {
+			int line = document.getLineOfOffset(event.getOffset());
+			int startOffset = document.getLineOffset(line);
+			int length = document.getLineLength(line);
+			
+			// Need to check up to length - 1 instead of length due to line feed char at end
+			this.lineBeforeChange = document.get(startOffset, length - 1);
+		} catch (BadLocationException e) {
+		}
+		return false;
+	}
+}

--- a/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
+++ b/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
@@ -38,12 +38,14 @@ public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
 			// Need to check up to length - 1 instead of length due to line feed char at end
 			String lineAfterChange = document.get(startOffset, length - 1);
 			
-			// Check that only the line's whitespace has changed, and that the line no longer
-			// ends with whitespace
-			boolean nonWhiteSpaceCharactersUnchanged = lineBeforeChange.trim().equals(lineAfterChange.trim());
-			boolean trailingWhiteSpaceBefore = lineBeforeChange.endsWith(" ") || lineBeforeChange.endsWith("\t");
-			boolean trailingWhiteSpaceAfter = lineAfterChange.endsWith(" ") || lineAfterChange.endsWith("\t");		
-			return nonWhiteSpaceCharactersUnchanged && trailingWhiteSpaceBefore && !trailingWhiteSpaceAfter;	
+			// If the change event is a deletion, check whether only the line's whitespace has
+			// changed, and that the line no longer ends with whitespace
+			if (event.getText().length() == 0) {
+				boolean nonWhiteSpaceCharactersUnchanged = lineBeforeChange.trim().equals(lineAfterChange.trim());
+				boolean trailingWhiteSpaceBefore = lineBeforeChange.endsWith(" ") || lineBeforeChange.endsWith("\t");
+				boolean trailingWhiteSpaceAfter = lineAfterChange.endsWith(" ") || lineAfterChange.endsWith("\t");
+				return nonWhiteSpaceCharactersUnchanged && trailingWhiteSpaceBefore && !trailingWhiteSpaceAfter;
+			}
 		} catch (BadLocationException e) {
 		}
 		return false;


### PR DESCRIPTION
Evaluates if the user is removing white space from lines manually. FE could use this, as there is an Eclipse setting to automatically remove white space on save that they can suggest to the user