### PR TITLE
Updated featureIDStrings management

### DIFF
--- a/backend_plugin/src/main/evaluators/AddImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/AddImportEvaluator.java
@@ -8,6 +8,8 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 
+import main.interfaces.FeatureSuggestion;
+
 public class AddImportEvaluator extends FeatureEvaluator {
 
 	private boolean unresolvedVariablesExist;
@@ -16,8 +18,8 @@ public class AddImportEvaluator extends FeatureEvaluator {
 	/**
 	 * Construct an AddImportEvaluator
 	 */
-	public AddImportEvaluator(String featureID, IDocument document) {
-		this.featureID = featureID;
+	public AddImportEvaluator(IDocument document) {
+		this.featureID = FeatureSuggestion.ADD_IMPORT_FEATURE_ID;
 		this.lineHadImportStatementAlready = false;
 		this.unresolvedVariablesExist = false;
 		this.document = document;

--- a/backend_plugin/src/main/evaluators/AddImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/AddImportEvaluator.java
@@ -8,7 +8,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 
-import main.interfaces.FeatureSuggestion;
+import main.interfaces.FeatureID;
 
 public class AddImportEvaluator extends FeatureEvaluator {
 
@@ -19,7 +19,7 @@ public class AddImportEvaluator extends FeatureEvaluator {
 	 * Construct an AddImportEvaluator
 	 */
 	public AddImportEvaluator(IDocument document) {
-		this.featureID = FeatureSuggestion.ADD_IMPORT_FEATURE_ID;
+		this.featureID = FeatureID.ADD_IMPORT_FEATURE_ID;
 		this.lineHadImportStatementAlready = false;
 		this.unresolvedVariablesExist = false;
 		this.document = document;

--- a/backend_plugin/src/main/evaluators/AddImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/AddImportEvaluator.java
@@ -16,8 +16,8 @@ public class AddImportEvaluator extends FeatureEvaluator {
 	/**
 	 * Construct an AddImportEvaluator
 	 */
-	public AddImportEvaluator(IDocument document) {
-		this.featureID = "addImportStatementsSuggestion";
+	public AddImportEvaluator(String featureID, IDocument document) {
+		this.featureID = featureID;
 		this.lineHadImportStatementAlready = false;
 		this.unresolvedVariablesExist = false;
 		this.document = document;
@@ -29,6 +29,7 @@ public class AddImportEvaluator extends FeatureEvaluator {
 	 * @param event
 	 * @return false
 	 */
+	@Override
 	public boolean evaluateDocumentBeforeChange(DocumentEvent event) {
 		try {
 
@@ -47,6 +48,7 @@ public class AddImportEvaluator extends FeatureEvaluator {
 	 * @param event
 	 * @return false
 	 */
+	@Override
 	public boolean evaluateDocumentChanges(DocumentEvent event) {
 		try {
 
@@ -59,7 +61,7 @@ public class AddImportEvaluator extends FeatureEvaluator {
 		}
 		return false;
 	}
-  
+
 	/**
 	 * Checks if the given line begins with an import statement
 	 * @param line

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -4,6 +4,8 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
+import main.interfaces.FeatureSuggestion;
+
 /**
  * Evaluates DocumentEvent changes to determine if the user is commenting out multiple sequential lines of code. If so,
  * then the user should be notified of the block comment feature in Eclipse.
@@ -16,8 +18,8 @@ public class BlockCommentEvaluator extends FeatureEvaluator {
 	/**
 	 * Default constructor
 	 */
-	public BlockCommentEvaluator(String featureID, IDocument document) {
-		this.featureID = featureID;
+	public BlockCommentEvaluator(IDocument document) {
+		this.featureID = FeatureSuggestion.BLOCK_COMMENT_FEATURE_ID;
 		this.document = document;
 		this.lastCommentedLine = -2;
 		this.lastCommentedLineTimeStamp = -1;

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -4,7 +4,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
-import main.interfaces.FeatureSuggestion;
+import main.interfaces.FeatureID;
 
 /**
  * Evaluates DocumentEvent changes to determine if the user is commenting out multiple sequential lines of code. If so,
@@ -19,7 +19,7 @@ public class BlockCommentEvaluator extends FeatureEvaluator {
 	 * Default constructor
 	 */
 	public BlockCommentEvaluator(IDocument document) {
-		this.featureID = FeatureSuggestion.BLOCK_COMMENT_FEATURE_ID;
+		this.featureID = FeatureID.BLOCK_COMMENT_FEATURE_ID;
 		this.document = document;
 		this.lastCommentedLine = -2;
 		this.lastCommentedLineTimeStamp = -1;

--- a/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
+++ b/backend_plugin/src/main/evaluators/BlockCommentEvaluator.java
@@ -12,25 +12,26 @@ public class BlockCommentEvaluator extends FeatureEvaluator {
 
 	private int lastCommentedLine;
 	private long lastCommentedLineTimeStamp;
-		
+
 	/**
 	 * Default constructor
 	 */
-	public BlockCommentEvaluator(IDocument document) {
-		this.featureID = "blockCommentSuggestion";
+	public BlockCommentEvaluator(String featureID, IDocument document) {
+		this.featureID = featureID;
 		this.document = document;
 		this.lastCommentedLine = -2;
 		this.lastCommentedLineTimeStamp = -1;
 	}
 
 	/**
-	 * Keeps track of DocumentEvent changes and determines of the user comments out multiple sequential lines of code. 
+	 * Keeps track of DocumentEvent changes and determines of the user comments out multiple sequential lines of code.
 	 * @param event the change detected by the DocumentChange Listener
 	 * @return true if the user comments two sequential lines of code, false otherwise
 	 */
+	@Override
 	public boolean evaluateDocumentChanges(DocumentEvent event) {
 		try {
-			
+
 			boolean triggered = false;
 
 			// Get the line number of the change
@@ -47,7 +48,7 @@ public class BlockCommentEvaluator extends FeatureEvaluator {
 				this.lastCommentedLine = line;
 				this.lastCommentedLineTimeStamp = System.currentTimeMillis();
 			}
-			
+
 			return triggered;
 		} catch (BadLocationException e) {
 			// This can happen in certain boundary positions (beginning and end) of the document. In these cases,
@@ -119,7 +120,7 @@ public class BlockCommentEvaluator extends FeatureEvaluator {
 		boolean lastCommentWasLongEnoughAgo = System.currentTimeMillis() - this.lastCommentedLineTimeStamp > 100;
 		return adjacentLineWasLastCommented && lastCommentWasLongEnoughAgo;
 	}
-	
+
 	/**
 	 * Checks if the given event caused the given line to be commented out
 	 * @param document The document the user is typing in

--- a/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
+++ b/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
@@ -4,6 +4,8 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
+import main.interfaces.FeatureSuggestion;
+
 /**
  * Evaluates DocumentEvent changes to determine if the user is changing the indentation of multiple sequential lines of code. If so,
  * then the user should be notified of the auto indentation feature in Eclipse.
@@ -18,8 +20,8 @@ public class CorrectIndentationEvaluator extends FeatureEvaluator {
      * Constructor
      * @param document IDocument that this evaluator is attached to
      */
-    public CorrectIndentationEvaluator(String featureID, IDocument document) {
-	this.featureID = featureID;
+    public CorrectIndentationEvaluator(IDocument document) {
+	this.featureID = FeatureSuggestion.CORRECT_INDENTATION_FEATURE_ID;
 	this.document = document;
 	// arbitrary default values to avoid special casing for the first document change
 	lineBeforeChange = "";

--- a/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
+++ b/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
@@ -18,8 +18,8 @@ public class CorrectIndentationEvaluator extends FeatureEvaluator {
      * Constructor
      * @param document IDocument that this evaluator is attached to
      */
-    public CorrectIndentationEvaluator(IDocument document) {
-	this.featureID = "correctIndentationsSuggestion";
+    public CorrectIndentationEvaluator(String featureID, IDocument document) {
+	this.featureID = featureID;
 	this.document = document;
 	// arbitrary default values to avoid special casing for the first document change
 	lineBeforeChange = "";

--- a/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
+++ b/backend_plugin/src/main/evaluators/CorrectIndentationEvaluator.java
@@ -4,7 +4,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
-import main.interfaces.FeatureSuggestion;
+import main.interfaces.FeatureID;
 
 /**
  * Evaluates DocumentEvent changes to determine if the user is changing the indentation of multiple sequential lines of code. If so,
@@ -21,7 +21,7 @@ public class CorrectIndentationEvaluator extends FeatureEvaluator {
      * @param document IDocument that this evaluator is attached to
      */
     public CorrectIndentationEvaluator(IDocument document) {
-	this.featureID = FeatureSuggestion.CORRECT_INDENTATION_FEATURE_ID;
+	this.featureID = FeatureID.CORRECT_INDENTATION_FEATURE_ID;
 	this.document = document;
 	// arbitrary default values to avoid special casing for the first document change
 	lineBeforeChange = "";

--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -8,6 +8,7 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
 import main.listeners.DocumentChangesListener;
+import main.interfaces.FeatureSuggestion;
 import main.listeners.AnnotationModelListener;
 
 
@@ -54,11 +55,11 @@ public class Evaluator {
 	 * @param textEditor The text document editor this Evaluator is evaluating
 	 */
 	private void initializeFeatureEvaluators(ITextEditor textEditor) {
-		this.featureEvaluators.add(new BlockCommentEvaluator(this.document));
-		this.featureEvaluators.add(new RemoveImportEvaluator(textEditor));
-		this.featureEvaluators.add(new AddImportEvaluator(this.document));
-		this.featureEvaluators.add(new CorrectIndentationEvaluator(this.document));
-		this.featureEvaluators.add(new TrailingWhiteSpaceEvaluator(this.document));
+		this.featureEvaluators.add(new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, this.document));
+		this.featureEvaluators.add(new RemoveImportEvaluator(FeatureSuggestion.REMOVE_IMPORT_EVAL, textEditor));
+		this.featureEvaluators.add(new AddImportEvaluator(FeatureSuggestion.ADD_IMPORT_EVAL, this.document));
+		this.featureEvaluators.add(new CorrectIndentationEvaluator(FeatureSuggestion.CORRECT_INDENTATION_EVAL, this.document));
+		this.featureEvaluators.add(new TrailingWhiteSpaceEvaluator(FeatureSuggestion.TRAILING_WHITE_SPACE_EVAL, this.document));
 	}
 
 	/**

--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -7,9 +7,9 @@ import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
-import main.listeners.DocumentChangesListener;
-import main.interfaces.FeatureSuggestion;
+
 import main.listeners.AnnotationModelListener;
+import main.listeners.DocumentChangesListener;
 
 
 /**

--- a/backend_plugin/src/main/evaluators/Evaluator.java
+++ b/backend_plugin/src/main/evaluators/Evaluator.java
@@ -55,11 +55,11 @@ public class Evaluator {
 	 * @param textEditor The text document editor this Evaluator is evaluating
 	 */
 	private void initializeFeatureEvaluators(ITextEditor textEditor) {
-		this.featureEvaluators.add(new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, this.document));
-		this.featureEvaluators.add(new RemoveImportEvaluator(FeatureSuggestion.REMOVE_IMPORT_EVAL, textEditor));
-		this.featureEvaluators.add(new AddImportEvaluator(FeatureSuggestion.ADD_IMPORT_EVAL, this.document));
-		this.featureEvaluators.add(new CorrectIndentationEvaluator(FeatureSuggestion.CORRECT_INDENTATION_EVAL, this.document));
-		this.featureEvaluators.add(new TrailingWhiteSpaceEvaluator(FeatureSuggestion.TRAILING_WHITE_SPACE_EVAL, this.document));
+		this.featureEvaluators.add(new BlockCommentEvaluator(this.document));
+		this.featureEvaluators.add(new RemoveImportEvaluator(textEditor));
+		this.featureEvaluators.add(new AddImportEvaluator(this.document));
+		this.featureEvaluators.add(new CorrectIndentationEvaluator(this.document));
+		this.featureEvaluators.add(new TrailingWhiteSpaceEvaluator(this.document));
 	}
 
 	/**

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -19,8 +19,8 @@ public class RemoveImportEvaluator extends FeatureEvaluator {
 	 * Constructor
 	 * @param docName the name of the document this evaluator is attached to
 	 */
-	public RemoveImportEvaluator(ITextEditor editor) {
-		this.featureID = "removeUnusedImportStatementsSuggestion";
+	public RemoveImportEvaluator(String featureID, ITextEditor editor) {
+		this.featureID = featureID;
 		this.editor = editor;
 	}
 

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -6,7 +6,7 @@ import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
 
-import main.interfaces.FeatureSuggestion;
+import main.interfaces.FeatureID;
 
 /**
  * Evaluator function to determine if there are any unused import statements in the current document. If any unused import
@@ -22,7 +22,7 @@ public class RemoveImportEvaluator extends FeatureEvaluator {
 	 * @param docName the name of the document this evaluator is attached to
 	 */
 	public RemoveImportEvaluator(ITextEditor editor) {
-		this.featureID = FeatureSuggestion.REMOVE_IMPORT_FEATURE_ID;
+		this.featureID = FeatureID.REMOVE_IMPORT_FEATURE_ID;
 		this.editor = editor;
 	}
 

--- a/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
+++ b/backend_plugin/src/main/evaluators/RemoveImportEvaluator.java
@@ -6,6 +6,8 @@ import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.ui.texteditor.ITextEditor;
 
+import main.interfaces.FeatureSuggestion;
+
 /**
  * Evaluator function to determine if there are any unused import statements in the current document. If any unused import
  * statements are found, then evaluate will return true
@@ -19,8 +21,8 @@ public class RemoveImportEvaluator extends FeatureEvaluator {
 	 * Constructor
 	 * @param docName the name of the document this evaluator is attached to
 	 */
-	public RemoveImportEvaluator(String featureID, ITextEditor editor) {
-		this.featureID = featureID;
+	public RemoveImportEvaluator(ITextEditor editor) {
+		this.featureID = FeatureSuggestion.REMOVE_IMPORT_FEATURE_ID;
 		this.editor = editor;
 	}
 

--- a/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
+++ b/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
@@ -4,6 +4,8 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
+import main.interfaces.FeatureSuggestion;
+
 /**
  * Evaluates DocumentEvent changes to determine if the user is manually deleting trailing white spaces
  * Eclipse has a setting to automatically remove trailing white spaces on save, so the user could use
@@ -17,8 +19,8 @@ public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
 	 * Constructs a TrailingWhiteSpaceEvaluator
 	 * @param document
 	 */
-	public TrailingWhiteSpaceEvaluator(String featureID, IDocument document) {
-		this.featureID = featureID;
+	public TrailingWhiteSpaceEvaluator(IDocument document) {
+		this.featureID = FeatureSuggestion.TRAILING_WHITE_SPACE_FEATURE_ID;
 		this.document = document;
 	}
 

--- a/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
+++ b/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
@@ -10,15 +10,15 @@ import org.eclipse.jface.text.IDocument;
  * this instead.
  */
 public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
-	
+
 	private String lineBeforeChange;
-	
+
 	/**
 	 * Constructs a TrailingWhiteSpaceEvaluator
 	 * @param document
 	 */
-	public TrailingWhiteSpaceEvaluator(IDocument document) {
-		this.featureID = "trailingWhiteSpaceSuggestion";
+	public TrailingWhiteSpaceEvaluator(String featureID, IDocument document) {
+		this.featureID = featureID;
 		this.document = document;
 	}
 
@@ -29,15 +29,15 @@ public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
 	 */
 	@Override
 	public boolean evaluateDocumentChanges(DocumentEvent event) {
-		
+
 		try {
 			int line = document.getLineOfOffset(event.getOffset());
 			int startOffset = document.getLineOffset(line);
 			int length = document.getLineLength(line);
-			
+
 			// Need to check up to length - 1 instead of length due to line feed char at end
 			String lineAfterChange = document.get(startOffset, length - 1);
-			
+
 			// If the change event is a deletion, check whether only the line's whitespace has
 			// changed, and that the line no longer ends with whitespace
 			if (event.getText().length() == 0) {
@@ -60,7 +60,7 @@ public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
 			int line = document.getLineOfOffset(event.getOffset());
 			int startOffset = document.getLineOffset(line);
 			int length = document.getLineLength(line);
-			
+
 			// Need to check up to length - 1 instead of length due to line feed char at end
 			this.lineBeforeChange = document.get(startOffset, length - 1);
 		} catch (BadLocationException e) {

--- a/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
+++ b/backend_plugin/src/main/evaluators/TrailingWhiteSpaceEvaluator.java
@@ -4,7 +4,7 @@ import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.DocumentEvent;
 import org.eclipse.jface.text.IDocument;
 
-import main.interfaces.FeatureSuggestion;
+import main.interfaces.FeatureID;
 
 /**
  * Evaluates DocumentEvent changes to determine if the user is manually deleting trailing white spaces
@@ -20,7 +20,7 @@ public class TrailingWhiteSpaceEvaluator extends FeatureEvaluator {
 	 * @param document
 	 */
 	public TrailingWhiteSpaceEvaluator(IDocument document) {
-		this.featureID = FeatureSuggestion.TRAILING_WHITE_SPACE_FEATURE_ID;
+		this.featureID = FeatureID.TRAILING_WHITE_SPACE_FEATURE_ID;
 		this.document = document;
 	}
 

--- a/backend_plugin/src/main/interfaces/FeatureID.java
+++ b/backend_plugin/src/main/interfaces/FeatureID.java
@@ -1,0 +1,33 @@
+package main.interfaces;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * This class is designed to single place of storage for the featureID strings.
+ * The strings will all be public and will allow any class, whether in the frontend or backend to use them liberally
+ */
+ public class FeatureID {
+
+     	// featureID strings used to communicate between frontend and backend
+  	// These must match EXACTLY with the agreed upon strings
+  	// A list of these strings can be found in featureIDStrings.txt in the main folder of this repo
+  	public static final String BLOCK_COMMENT_FEATURE_ID = "blockCommentSuggestion";
+  	public static final String ADD_IMPORT_FEATURE_ID = "addImportStatementsSuggestion";
+  	public static final String CORRECT_INDENTATION_FEATURE_ID = "correctIndentationsSuggestion";
+  	public static final String REMOVE_IMPORT_FEATURE_ID = "removeUnusedImportStatementSuggestion";
+  	public static final String TRAILING_WHITE_SPACE_FEATURE_ID = "trailingWhiteSpaceSuggestion";
+
+
+  	private static final List<String> featureIDs = Arrays.asList(BLOCK_COMMENT_FEATURE_ID,
+  									ADD_IMPORT_FEATURE_ID,
+  									CORRECT_INDENTATION_FEATURE_ID,
+  									REMOVE_IMPORT_FEATURE_ID,
+  									TRAILING_WHITE_SPACE_FEATURE_ID);
+
+  	public static List<String> getAllFeatureIDs() {
+  	    return new ArrayList<String>(featureIDs);
+  	}
+
+}

--- a/backend_plugin/src/main/interfaces/FeatureSuggestion.java
+++ b/backend_plugin/src/main/interfaces/FeatureSuggestion.java
@@ -1,32 +1,41 @@
 package main.interfaces;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import main.evaluators.EvaluatorManager;
 
-/** Designed to be used in conjunction with the FeatureSuggestionObserver class. 
- * Observers can register themselves with FeatureSuggestions. FeatureSuggestion will 
- * notify all registered Observers with features it detects the user may want to be 
+/** Designed to be used in conjunction with the FeatureSuggestionObserver class.
+ * Observers can register themselves with FeatureSuggestions. FeatureSuggestion will
+ * notify all registered Observers with features it detects the user may want to be
  * aware of.
  */
 public class FeatureSuggestion implements FeatureSuggestionInterface {
-	
+
 	private EvaluatorManager manager;
 	private List<FeatureSuggestionObserver> observers;
 	private List<String> featureIDs;
 	private boolean isRunning;
-	
+
+	// featureID strings used to communicate between frontend and backend
+	// These must match EXACTLY with the agreed upon strings
+	// A list of these strings can be found in featureIDStrings.txt in the main folder of this repo
+	public static final String BLOCK_COMMENT_EVAL = "blockCommentSuggestion";
+	public static final String ADD_IMPORT_EVAL = "addImportStatementsSuggestion";
+	public static final String CORRECT_INDENTATION_EVAL = "correctIndentationsSuggestion";
+	public static final String REMOVE_IMPORT_EVAL = "removeUnusedImportStatementSuggestion";
+	public static final String TRAILING_WHITE_SPACE_EVAL = "trailingWhiteSpaceSuggestion";
+
 	public FeatureSuggestion() {
 		// debug
 		System.out.println("FS created");
-		
 		manager = new EvaluatorManager(this);
 		observers = new ArrayList<FeatureSuggestionObserver>();
 		featureIDs = generateFeatureIDs();
 		isRunning = false;
 	}
-	
+
 	/**
 	 * Register an Observer to be notified upon FeatureSuggestion updates
 	 * @param obs Observer to be registered
@@ -36,7 +45,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	public boolean registerObserver(FeatureSuggestionObserver obs) {
 		return observers.add(obs);
 	}
-	
+
 	/**
 	 * Removes an observer from the FeatureSuggestion observer list. The observer
 	 * will no longer be updated on FeatureSuggestion updates
@@ -47,7 +56,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	public boolean removeObserver(FeatureSuggestionObserver obs) {
 		return observers.remove(obs);
 	}
-	
+
 	/**
 	 * Provides a list of all featureIDs used by FeatureSuggestion.
 	 * Recommended to use this list to verify observer featureID list matches
@@ -58,7 +67,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 		List<String> feats = new ArrayList<String>(featureIDs);
 		return feats;
 	}
-	
+
 	/**
 	 * Turns the FeatureSuggestion on. All observers will be updated upon updates.
 	 */
@@ -66,8 +75,8 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	public void start() {
 		this.manager.start();
 		isRunning = true;
-		
-		// Debug 
+
+		// Debug
 		System.out.println("Starting fs");
 	}
 
@@ -78,7 +87,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	public void stop() {
 		this.manager.stop();
 		isRunning = false;
-		
+
 		// Debug
 		System.out.println("Stopping fs");
 	}
@@ -90,23 +99,25 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	public boolean isRunning() {
 		return isRunning;
 	}
-	
+
 	/**
 	 * Generate list of FeatureIDs to be tracked
-	 * 
+	 *
 	 * @return List of FeatureIDs to be tracked
 	 */
 	private List<String> generateFeatureIDs() {
-		// Either read from a file or hard code in
-		// Pros and cons to both
-		List<String> feats = new ArrayList<String>();
-		feats.add("multiline_comment");
-		return feats;
+	    	List<String> feats = new ArrayList<String>();
+	    	feats.add(BLOCK_COMMENT_EVAL);
+	    	feats.add(ADD_IMPORT_EVAL);
+	    	feats.add(CORRECT_INDENTATION_EVAL);
+	    	feats.add(REMOVE_IMPORT_EVAL);
+	    	feats.add(TRAILING_WHITE_SPACE_EVAL);
+		return Collections.unmodifiableList(feats);
 	}
-	
+
 	/**
 	 * Notifies all observers that a feature should be suggested to the user
-	 * 
+	 *
 	 * @param featureID string that represents a featureID
 	 */
 	public void notifyAllObservers(String featureID) {

--- a/backend_plugin/src/main/interfaces/FeatureSuggestion.java
+++ b/backend_plugin/src/main/interfaces/FeatureSuggestion.java
@@ -1,7 +1,6 @@
 package main.interfaces;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import main.evaluators.EvaluatorManager;
@@ -15,24 +14,13 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 
 	private EvaluatorManager manager;
 	private List<FeatureSuggestionObserver> observers;
-	private List<String> featureIDs;
 	private boolean isRunning;
-
-	// featureID strings used to communicate between frontend and backend
-	// These must match EXACTLY with the agreed upon strings
-	// A list of these strings can be found in featureIDStrings.txt in the main folder of this repo
-	public static final String BLOCK_COMMENT_FEATURE_ID = "blockCommentSuggestion";
-	public static final String ADD_IMPORT_FEATURE_ID = "addImportStatementsSuggestion";
-	public static final String CORRECT_INDENTATION_FEATURE_ID = "correctIndentationsSuggestion";
-	public static final String REMOVE_IMPORT_FEATURE_ID = "removeUnusedImportStatementSuggestion";
-	public static final String TRAILING_WHITE_SPACE_FEATURE_ID = "trailingWhiteSpaceSuggestion";
 
 	public FeatureSuggestion() {
 		// debug
 		System.out.println("FS created");
 		manager = new EvaluatorManager(this);
 		observers = new ArrayList<FeatureSuggestionObserver>();
-		featureIDs = generateFeatureIDs();
 		isRunning = false;
 	}
 
@@ -64,8 +52,7 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	 */
 	@Override
 	public List<String> getAllFeatureIDs() {
-		List<String> feats = new ArrayList<String>(featureIDs);
-		return feats;
+		return FeatureID.getAllFeatureIDs();
 	}
 
 	/**
@@ -98,21 +85,6 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	@Override
 	public boolean isRunning() {
 		return isRunning;
-	}
-
-	/**
-	 * Generate list of FeatureIDs to be tracked
-	 *
-	 * @return List of FeatureIDs to be tracked
-	 */
-	private List<String> generateFeatureIDs() {
-	    	List<String> feats = new ArrayList<String>();
-	    	feats.add(BLOCK_COMMENT_FEATURE_ID);
-	    	feats.add(ADD_IMPORT_FEATURE_ID);
-	    	feats.add(CORRECT_INDENTATION_FEATURE_ID);
-	    	feats.add(REMOVE_IMPORT_FEATURE_ID);
-	    	feats.add(TRAILING_WHITE_SPACE_FEATURE_ID);
-		return Collections.unmodifiableList(feats);
 	}
 
 	/**

--- a/backend_plugin/src/main/interfaces/FeatureSuggestion.java
+++ b/backend_plugin/src/main/interfaces/FeatureSuggestion.java
@@ -21,11 +21,11 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	// featureID strings used to communicate between frontend and backend
 	// These must match EXACTLY with the agreed upon strings
 	// A list of these strings can be found in featureIDStrings.txt in the main folder of this repo
-	public static final String BLOCK_COMMENT_EVAL = "blockCommentSuggestion";
-	public static final String ADD_IMPORT_EVAL = "addImportStatementsSuggestion";
-	public static final String CORRECT_INDENTATION_EVAL = "correctIndentationsSuggestion";
-	public static final String REMOVE_IMPORT_EVAL = "removeUnusedImportStatementSuggestion";
-	public static final String TRAILING_WHITE_SPACE_EVAL = "trailingWhiteSpaceSuggestion";
+	public static final String BLOCK_COMMENT_FEATURE_ID = "blockCommentSuggestion";
+	public static final String ADD_IMPORT_FEATURE_ID = "addImportStatementsSuggestion";
+	public static final String CORRECT_INDENTATION_FEATURE_ID = "correctIndentationsSuggestion";
+	public static final String REMOVE_IMPORT_FEATURE_ID = "removeUnusedImportStatementSuggestion";
+	public static final String TRAILING_WHITE_SPACE_FEATURE_ID = "trailingWhiteSpaceSuggestion";
 
 	public FeatureSuggestion() {
 		// debug
@@ -107,11 +107,11 @@ public class FeatureSuggestion implements FeatureSuggestionInterface {
 	 */
 	private List<String> generateFeatureIDs() {
 	    	List<String> feats = new ArrayList<String>();
-	    	feats.add(BLOCK_COMMENT_EVAL);
-	    	feats.add(ADD_IMPORT_EVAL);
-	    	feats.add(CORRECT_INDENTATION_EVAL);
-	    	feats.add(REMOVE_IMPORT_EVAL);
-	    	feats.add(TRAILING_WHITE_SPACE_EVAL);
+	    	feats.add(BLOCK_COMMENT_FEATURE_ID);
+	    	feats.add(ADD_IMPORT_FEATURE_ID);
+	    	feats.add(CORRECT_INDENTATION_FEATURE_ID);
+	    	feats.add(REMOVE_IMPORT_FEATURE_ID);
+	    	feats.add(TRAILING_WHITE_SPACE_FEATURE_ID);
 		return Collections.unmodifiableList(feats);
 	}
 

--- a/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import main.evaluators.BlockCommentEvaluator;
-import main.interfaces.FeatureSuggestion;
 
 /**
  * Unit test for BlockCommentEvaluator

--- a/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
@@ -36,7 +36,7 @@ public class BlockCommentEvaluatorTest {
 	public void runBeforeTests() {
 		// Create a document with four lines
 		doc = new Document(content);
-		testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
+		testEvaluator = new BlockCommentEvaluator(doc);
 	}
 
 	/**

--- a/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
+++ b/backend_plugin/src/test/java/BlockCommentEvaluatorTest.java
@@ -12,12 +12,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import main.evaluators.BlockCommentEvaluator;
+import main.interfaces.FeatureSuggestion;
 
 /**
  * Unit test for BlockCommentEvaluator
  */
 public class BlockCommentEvaluatorTest {
-	
+
 	private static final String content = "Line1\n Line2\n Line3\n";
 	private static final String SINGLE_SLASH = "/";
 
@@ -35,7 +36,7 @@ public class BlockCommentEvaluatorTest {
 	public void runBeforeTests() {
 		// Create a document with four lines
 		doc = new Document(content);
-		testEvaluator = new BlockCommentEvaluator(doc);
+		testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
 	}
 
 	/**
@@ -43,7 +44,7 @@ public class BlockCommentEvaluatorTest {
 	 */
 	@Test
 	public void twoConsecutiveLinesDownCommentedOut() {
-		// Mock a document event with a single backslash placed at the beginning of the first line		
+		// Mock a document event with a single backslash placed at the beginning of the first line
 		try {
 			// Mock a document event with a single backslash placed at the beginning of the first line
 			offset = 0;
@@ -64,7 +65,7 @@ public class BlockCommentEvaluatorTest {
 			doc.replace(offset, 0, SINGLE_SLASH);
 			event = createDocEvent(offset, SINGLE_SLASH);
 			assertFalse(testEvaluator.evaluateDocumentChanges(event));
-			
+
 			// Place a second backslash after the first
 			offset++;
 			doc.replace(offset, 0, SINGLE_SLASH);
@@ -154,7 +155,7 @@ public class BlockCommentEvaluatorTest {
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluateDocumentChanges(event));
-			
+
 			delayUserInput();
 
 			// Comment out the third line
@@ -194,7 +195,7 @@ public class BlockCommentEvaluatorTest {
 			doc.replace(offset, 0, SINGLE_SLASH);
 			event = createDocEvent(offset, SINGLE_SLASH);
 			assertFalse(testEvaluator.evaluateDocumentChanges(event));
-			
+
 			delayUserInput();
 
 			// Mock a document event with a single backslash placed at the beginning of the second line
@@ -209,7 +210,7 @@ public class BlockCommentEvaluatorTest {
 			event = createDocEvent(offset, SINGLE_SLASH);
 			// Now the evaluation function should trigger
 			assertTrue(testEvaluator.evaluateDocumentChanges(event));
-			
+
 			delayUserInput();
 
 			// Mock a document event with a single backslash placed at the beginning of the first line

--- a/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
+++ b/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
@@ -12,7 +12,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import main.evaluators.BlockCommentEvaluator;
-import main.interfaces.FeatureSuggestion;
 
 /**
  * Tests against all known sequences of actions a user can take to manually attempt to comment out multiple lines

--- a/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
+++ b/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
@@ -39,7 +39,7 @@ public class BlockCommentNegative {
 	public void runBeforeTests() {
 		// Create a document with four lines
 		doc = new Document(content);
-		testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
+		testEvaluator = new BlockCommentEvaluator(doc);
 	}
 
 	/**
@@ -671,7 +671,7 @@ public class BlockCommentNegative {
 			// Create a new document that has 6 lines, two being blank
 			// Contrived to make deleting other lines easier
 			doc = new Document("\nLine2\n\nLine3\nLine4");
-			testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
+			testEvaluator = new BlockCommentEvaluator(doc);
 
 			// Mock a document event with a single backslash placed at the beginning of the first line
 			offset = doc.getLineOffset(0);
@@ -716,7 +716,7 @@ public class BlockCommentNegative {
 			// Create a new document that has 6 lines, two being blank
 			// Contrived to make deleting other lines easier
 			doc = new Document("\nLine2\n\nLine3\nLine4");
-			testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
+			testEvaluator = new BlockCommentEvaluator(doc);
 
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);

--- a/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
+++ b/backend_plugin/src/test/java/negatives/evaluators/BlockCommentNegative.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import main.evaluators.BlockCommentEvaluator;
+import main.interfaces.FeatureSuggestion;
 
 /**
  * Tests against all known sequences of actions a user can take to manually attempt to comment out multiple lines
@@ -38,7 +39,7 @@ public class BlockCommentNegative {
 	public void runBeforeTests() {
 		// Create a document with four lines
 		doc = new Document(content);
-		testEvaluator = new BlockCommentEvaluator(doc);
+		testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
 	}
 
 	/**
@@ -670,7 +671,7 @@ public class BlockCommentNegative {
 			// Create a new document that has 6 lines, two being blank
 			// Contrived to make deleting other lines easier
 			doc = new Document("\nLine2\n\nLine3\nLine4");
-			testEvaluator = new BlockCommentEvaluator(doc);
+			testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
 
 			// Mock a document event with a single backslash placed at the beginning of the first line
 			offset = doc.getLineOffset(0);
@@ -715,7 +716,7 @@ public class BlockCommentNegative {
 			// Create a new document that has 6 lines, two being blank
 			// Contrived to make deleting other lines easier
 			doc = new Document("\nLine2\n\nLine3\nLine4");
-			testEvaluator = new BlockCommentEvaluator(doc);
+			testEvaluator = new BlockCommentEvaluator(FeatureSuggestion.BLOCK_COMMENT_EVAL, doc);
 
 			// Mock a document event with a single backslash placed at the beginning of the third line
 			offset = doc.getLineOffset(2);

--- a/featureIDStrings.txt
+++ b/featureIDStrings.txt
@@ -1,5 +1,6 @@
 blockCommentSuggestion
 addImportStatementsSuggestion
-removeUnusedImportsStatementSuggestion
+removeUnusedImportStatementSuggestion
 correctIndentationsSuggestion
+trailingWhiteSpaceSuggestion
 variableRenameRefactorSuggestion


### PR DESCRIPTION
All FeatureIDStrings are now only stored in the FeatureSuggestion class.

This allows us to only have one location where we store, and reference all featureID strings. 

This required a minor change in all evaluation classes. We now need to pass in the correct featureID string, since the evaluator doesn't have a reference to the FS object.

...Also, Eclipse changed some spacing / new lines that shows up in the commit that's really annoying to read through. Sorry about that. 