### PR TITLE
No longer triggers when adding white space to end of line

### DIFF
--- a/backend_plugin/src/main/evaluators/GetterSetterEvaluator.java
+++ b/backend_plugin/src/main/evaluators/GetterSetterEvaluator.java
@@ -64,7 +64,8 @@ public class GetterSetterEvaluator extends FeatureEvaluator {
 		try {
 			int lineOffset = document.getLineOffset(line);
 			int lineLength = document.getLineLength(line);
-			String lineText = document.get(lineOffset, lineLength).trim().toLowerCase();
+			String lineText = document.get(lineOffset, lineLength).toLowerCase();
+			lineText = trimStartAndNewLine(lineText);
 
 			// check for public or protected at the start of the line
 			if (lineText.startsWith("public ") || lineText.startsWith("protected ")) {
@@ -72,7 +73,7 @@ public class GetterSetterEvaluator extends FeatureEvaluator {
 				// check if we've already parsed the AST for this line change
 				if (this.lastLineChanged != line) {
 
-					// If not, then update the variable names while editing this line
+				    	// If not, then update the variable names while editing this line
 					// This operation is costly, so we limit it to only when it's necessary
 					updateKnownVariableNames();
 					this.lastLineChanged = line;
@@ -142,5 +143,14 @@ public class GetterSetterEvaluator extends FeatureEvaluator {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Helper method to remove the leading white space of a string and any newline characters
+	 * @param text to remove the leading white space from
+	 * @return a string with all leading white space removed
+	 */
+	private String trimStartAndNewLine(String text) {
+	    return text.replaceFirst("^\\s+", "").replace("\n", "");
 	}
 }

--- a/backend_plugin/src/test/java/evaluators/GetterSetterEvaluatorTest.java
+++ b/backend_plugin/src/test/java/evaluators/GetterSetterEvaluatorTest.java
@@ -213,6 +213,23 @@ public class GetterSetterEvaluatorTest {
 	}
 
 	/**
+	 * Verify evaluation does NOT trigger when adding spaces to the end of the method declaration
+	 */
+	@Test
+	public void oneCharacterAtATimeGetXWithSpaces() {
+	    try {
+		int offset = doc.getLineOffset(4);
+		for (char c : "public int get".toCharArray()) {
+		    assertFalse(mockUserInput(String.valueOf(c), offset++));
+		}
+		assertTrue(mockUserInput(INT_VAR_NAME, offset++));
+
+		// Now add a space, and the evaluation should NOT trigger
+		assertFalse(mockUserInput(" ", offset++));
+	    } catch (BadLocationException e) {}
+	}
+
+	/**
 	 * Mocks the user typing the given string into the document at
 	 * the given offset. Evaluates the result to see if the feature
 	 * evaluation has been triggered

--- a/backend_plugin/src/test/java/evaluators/negativeCases/GetterSetterNegativeCases.java
+++ b/backend_plugin/src/test/java/evaluators/negativeCases/GetterSetterNegativeCases.java
@@ -1,6 +1,7 @@
 package test.java.evaluators.negativeCases;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -194,6 +195,22 @@ public class GetterSetterNegativeCases {
 	    } catch (BadLocationException e) {}
 	}
 
+	/**
+	 * Verify evaluation does NOT trigger when adding spaces to the end of the method declaration
+	 */
+	@Test
+	public void oneCharacterAtATimeGetXWithSpaces() {
+	    try {
+		int offset = doc.getLineOffset(4);
+		for (char c : "public int get".toCharArray()) {
+		    assertFalse(mockUserInput(String.valueOf(c), offset++));
+		}
+		assertTrue(mockUserInput(INT_VAR_NAME, offset++));
+
+		// Now add a space, and the evaluation should NOT trigger
+		assertFalse(mockUserInput(" ", offset++));
+	    } catch (BadLocationException e) {}
+	}
 
 	/**
 	 * Mocks the user typing the given string into the document at


### PR DESCRIPTION
Updated GetterSetter suggestion.

It was previously trimming all white space from a line and using the result to check if a get or set method declaration was typed out. However, if you typed out the method declaration and then added spaces after it, the notification would repeatedly trigger. 

It's been changed to only remove the leading white space of the line of text, and also the newline character at the end (if it exists), and using that to check if the method declaration was typed out.

A test checking that adding white space does not trigger the evaluation function has been added to the unit tests and the negative tests for this evaluator.